### PR TITLE
temporal flexibility

### DIFF
--- a/configs/example_config.conf
+++ b/configs/example_config.conf
@@ -20,6 +20,8 @@
 #	 <Mmm>	 - converted to three letter month abbreviation, e.g. Jan for January
 #    <MMM>	 - uppercase three letter month abbreviation, e.g. JAN
 #    <mmm>	 - lowercase three letter month abbreviation, e.g. jan
+#	 <DD>	 - two digit decimal representation of the day of the month, e.g. 01 for the 1st day of the month
+#	 <DDD>	 - three digit decimal representation of the day of the year, e.g. 123 for 3rd May (124 on a leap year)
 #
 # In addition to these tokens, filename patterns can be specified using ? and * which
 # follow the standard Unix glob behaviour.
@@ -34,6 +36,9 @@ src_home = fluxengine_src
 # Woolf et al., 2012.
 flux_calc = rapid
 
+# Daily temporal resolution switch. Setting to 'yes' will calculate the flux for each day in each month.
+# If using this option, as least some of your input data should be daily.
+daily_resolution = no
 
 # Sea surface temperature to use (valid options are 'yes' or 'no').
 # If only one is enabled the other will be derived according to, i.e.:

--- a/configs/example_config.conf
+++ b/configs/example_config.conf
@@ -64,7 +64,7 @@ time_prod = time
 # pCO2/fCO2 annual extrapolation from a reference year (set pco2_annual_extrapolation = 0.0 to turn off).
 #
 pco2_reference_year = 2010
-pco2_annual_extrapolation = 0.0
+pco2_annual_correction = 0.0
 
 # 
 # Input data layers and their associated data variable names
@@ -231,7 +231,7 @@ bias_k_wind_value = 0.0
 #
 k_parameterisation = k_Nightingale2000
 
-# generic k parameterisation
+# generic k parameterisation (only used when k_parameterisation = k_generic)
 #k_generic_sc = 660.0
 #k_generic_a0 = 1.0
 #k_generic_a1 = 0.0
@@ -243,9 +243,10 @@ k_parameterisation = k_Nightingale2000
 # Weighting for kb and kd components of k_GoddijnMurphy_Fangohr2012 k parameterisation
 # Setting both equal to 1.0 means that the total k will simply be a linear combination
 # These need to both be valid real numbers
+# Only used for certain k parameterisation options: kt_OceanFluxGHG, kt_OceanFluxGHG_kd_wind and k_Wanninkhof2013
 #
-kd_weighting = 1.0
-kb_weighting = 1.0
+#kd_weighting = 1.0
+#kb_weighting = 1.0
 
 # asymmetry switch for OceanFlux k paramterisation
 # default is 1.0 ie no asymmetry

--- a/configs/example_config.conf
+++ b/configs/example_config.conf
@@ -32,7 +32,7 @@ src_home = fluxengine_src
 # Flux calculation options. Valid options are 'bulk', 'rapid' or 'equilibrium'
 # 'rapid' and 'equilibrium' are in relation to the flux model as described in
 # Woolf et al., 2012.
-flux_calc = bulk
+flux_calc = rapid
 
 
 # Sea surface temperature to use (valid options are 'yes' or 'no').
@@ -42,29 +42,29 @@ flux_calc = bulk
 # At least one must be selected.
 use_sstskin = yes
 use_sstfnd = no
-sst_gradients = no
-cool_skin_difference = 0.0
+sst_gradients = yes
+cool_skin_difference = 0.17
 
 # ...
 
-saline_skin_value = 0.0
-
+#sstgrad_path = data/validation_data/SST_gradients/<MM>-UKMO-L4LRfnd-GLOB-???-????-*.nc
+#sstgrad_prod = gradient_fields
+saline_skin_value = 0.1
 
 # Latitude, longitude and time product names (these are taken from the data layer names in
 # axes_data_layer, which must contain the name of datalayer defined below, e.g. 'sstskin').
 # Typically 'lat' and 'lon' unless using Takahashi which is 'latitude' and 'longitude'.
 axes_data_layer = sstskin
-latitude_prod = latitude
-longitude_prod = longitude
+latitude_prod = lat
+longitude_prod = lon
 time_prod = time
 
 
 #
 # pCO2/fCO2 annual extrapolation from a reference year (set pco2_annual_extrapolation = 0.0 to turn off).
 #
-pco2_reference_year = 2000
+pco2_reference_year = 2010
 pco2_annual_extrapolation = 0.0
-
 
 # 
 # Input data layers and their associated data variable names
@@ -91,22 +91,55 @@ pco2_annual_extrapolation = 0.0
 
 
 # sst skin data inputs
-sstskin_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-sstskin_prod = SST_t
-sstskin_preprocessing = celsius_to_kelvin
+sstskin_path = data/validation_data/SST/<YYYY>/*<YYYY><MM>*OCF-???-???-1M-*.nc
+sstskin_prod = sst_skin_mean
+sstskin_stddev_prod = auto
+sstskin_count_prod = auto
+
 
 # U10 wind data inputs
-windu10_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-windu10_prod = wind_t
+windu10_path = data/validation_data/globwave/<YYYY>/*<YYYY><MM>*OCF-???-???-1M-*.nc
+windu10_prod = wind_speed_cor_mean
+windu10_stddev_prod = auto
+windu10_count_prod = auto
+
+windu10_moment2_path = data/validation_data/globwave/<YYYY>/*<YYYY><MM>*OCF-???-???-1M-*.nc
+windu10_moment2_prod = wind_speed_cor_moment_2
+
+windu10_moment3_path = data/validation_data/globwave/<YYYY>/*<YYYY><MM>*OCF-???-???-1M-*.nc
+windu10_moment3_prod = wind_speed_cor_moment_3
+
+
+# sigma0 (radar backscatter) data inputs
+sigma0_path = data/validation_data/sigma0/<YYYY>/*<YYYY><MM>*_OCF-SI0-???-1M-*-*.nc
+sigma0_prod = sigma0_cal_mean
+
+
+# significant wave height data inputs
+sig_wv_ht_path = data/validation_data/sig_wv_ht/<YYYY>/*<YYYY><MM>*_OCF-SSH-???-1M-*-*.nc
+sig_wv_ht_prod = swhcor_mean
+sig_wv_ht_stddev_prod = auto
+sig_wv_ht_count_prod = auto
+
 
 # ice data
-ice_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-ice_prod = sea_ice_coverage
-ice_preprocessing = percent_to_proportion
+ice_path = data/validation_data/ice/<YYYY>/2010<MM>*_???-ICE-???-1M-*-*.nc
+ice_prod = sea_ice_fraction_mean
+
+# rain intensity data inputs
+# two options, either 'trmm' or 'gpgp'
+# TRMM is limited to +/-60 degrees latitude ie there are no rain data in polar and sub-polar regions
+# GPCP is has full global coverage
+#
+rain_data_selection = gpcp
+rain_path = data/validation_data/rain_gpcp/<YYYY>/gpcp_v22.<YYYY><MM>.nc
+rain_prod = Precip
+rain_preprocessing = transpose, flip_longitude, flip_latitude
 
 # modelled air pressure data.
-pressure_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-pressure_prod = pressure
+pressure_path = data/validation_data/air_pressure/<YYYY>/*<YYYY><MM>*OCF-???-???-1M-*.nc
+pressure_prod = msl_mean
+pressure_preprocessing = pascal_to_millibar
 
 # Salinity data
 salinity_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
@@ -122,19 +155,19 @@ salinity_prod = salinity
 # if 'taka' option selected then the 1.5 uatm per year increment is not added to the values in the flux calculation
 # pCO2 and fCO2 are handled in the same way, so with the SOCAT option you can either use pCO2 or fCO2 data
 #
-pco2_data_selection = taka
+pco2_data_selection = socat_pco2
 
-vco2_air_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-vco2_air_prod = vCO2_air
+vco2_air_path = data/validation_data/SOCATv4/<YYYY><MM>01_OCF-CO2-GLO-1M-KRG-CLIM.nc
+vco2_air_prod = vCO2
+vco2_air_preprocessing = flip_longitude
 
-pco2_air_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-pco2_air_prod = pCO2_air
+pco2_sw_path = data/validation_data/SOCATv4/<YYYY><MM>01_OCF-CO2-GLO-1M-KRG-CLIM.nc
+pco2_sw_prod = pCO2_2010_interpolated_pred
+pco2_sw_preprocessing = flip_longitude
 
-pco2_sw_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-pco2_sw_prod = pCO2_sw
-
-pco2_sst_path = data/validation_data/takahashi09/M2001*<mmm>*.nc
-pco2_sst_prod = SST_t
+pco2_sst_path = data/validation_data/SOCATv4/<YYYY><MM>01_OCF-CO2-GLO-1M-KRG-CLIM.nc
+pco2_sst_prod = Tcl_2010
+pco2_sst_preprocessing = flip_longitude, kelvin_to_celsius
 
 
 #
@@ -196,14 +229,14 @@ bias_k_wind_value = 0.0
 # these should be specified by name, e.g.:
 # k_generic_sc = 660.0
 #
-k_parameterisation = k_generic
+k_parameterisation = k_Nightingale2000
 
 # generic k parameterisation
-k_generic_sc = 660.0
-k_generic_a0 = 0.0
-k_generic_a1 = 0.0
-k_generic_a2 = 0.26
-k_generic_a3 = 0.0
+#k_generic_sc = 660.0
+#k_generic_a0 = 1.0
+#k_generic_a1 = 0.0
+#k_generic_a2 = 0.0
+#k_generic_a3 = 0.0
 
 
 #
@@ -240,4 +273,4 @@ k_rain_nonlinear_h2012 = no
 #
 # Output directory for the resultant netcdf files
 #
-output_dir = output/validate_takahashi09
+output_dir = output/validate_socatv4_sst_salinity_N00

--- a/configs/socatv4_sst_salinity_gradients-N00.conf
+++ b/configs/socatv4_sst_salinity_gradients-N00.conf
@@ -20,6 +20,8 @@
 #	 <Mmm>	 - converted to three letter month abbreviation, e.g. Jan for January
 #    <MMM>	 - uppercase three letter month abbreviation, e.g. JAN
 #    <mmm>	 - lowercase three letter month abbreviation, e.g. jan
+#	 <DD>	 - two digit decimal representation of the day of the month, e.g. 01 for the 1st day of the month
+#	 <DDD>	 - three digit decimal representation of the day of the year, e.g. 123 for 3rd May (124 on a leap year)
 #
 # In addition to these tokens, filename patterns can be specified using ? and * which
 # follow the standard Unix glob behaviour.
@@ -34,6 +36,9 @@ src_home = fluxengine_src
 # Woolf et al., 2012.
 flux_calc = rapid
 
+# Daily temporal resolution switch. Setting to 'yes' will calculate the flux for each day in each month.
+# If using this option, as least some of your input data should be daily.
+daily_resolution = no
 
 # Sea surface temperature to use (valid options are 'yes' or 'no').
 # If only one is enabled the other will be derived according to, i.e.:

--- a/configs/socatv4_sst_salinity_gradients-N00.conf
+++ b/configs/socatv4_sst_salinity_gradients-N00.conf
@@ -61,7 +61,7 @@ time_prod = time
 # pCO2/fCO2 annual extrapolation from a reference year (set pco2_annual_extrapolation = 0.0 to turn off).
 #
 pco2_reference_year = 2010
-pco2_annual_extrapolation = 0.0
+pco2_annual_correction = 0.0
 
 # 
 # Input data layers and their associated data variable names
@@ -228,26 +228,10 @@ bias_k_wind_value = 0.0
 #
 k_parameterisation = k_Nightingale2000
 
-# generic k parameterisation
-#k_generic_sc = 660.0
-#k_generic_a0 = 1.0
-#k_generic_a1 = 0.0
-#k_generic_a2 = 0.0
-#k_generic_a3 = 0.0
 
-
-#
-# Weighting for kb and kd components of k_GoddijnMurphy_Fangohr2012 k parameterisation
-# Setting both equal to 1.0 means that the total k will simply be a linear combination
-# These need to both be valid real numbers
-#
-kd_weighting = 1.0
-kb_weighting = 1.0
-
-# asymmetry switch for OceanFlux k paramterisation
+# asymmetry for OceanFlux k paramterisation
 # default is 1.0 ie no asymmetry
-# the option above 'k_t_OceanFluxGHG =' must be set to 'yes' for this to be used
-#
+# this option is only used when k_parameterisation = kt_OceanFluxGHG.
 kb_asymmetry = 1.00
 
 

--- a/configs/socatv4_sst_salinity_gradients-N00.conf
+++ b/configs/socatv4_sst_salinity_gradients-N00.conf
@@ -42,12 +42,10 @@ flux_calc = rapid
 # At least one must be selected.
 use_sstskin = yes
 use_sstfnd = no
+sst_gradients = yes
 cool_skin_difference = 0.17
 
 # ...
-sst_gradients = yes
-sstgrad_path = data/validation_data/SST_gradients/<MM>-UKMO-L4LRfnd-GLOB-???-????-*.nc
-sstgrad_prod = gradient_fields
 saline_skin_value = 0.1
 
 # Latitude, longitude and time product names (these are taken from the data layer names in

--- a/configs/takahashi09_validation.conf
+++ b/configs/takahashi09_validation.conf
@@ -63,7 +63,7 @@ time_prod = time
 # pCO2/fCO2 annual extrapolation from a reference year (set pco2_annual_extrapolation = 0.0 to turn off).
 #
 pco2_reference_year = 2000
-pco2_annual_extrapolation = 0.0
+pco2_annual_correction = 0.0
 
 
 # 
@@ -206,17 +206,9 @@ k_generic_a2 = 0.26
 k_generic_a3 = 0.0
 
 
-#
-# Weighting for kb and kd components of k_GoddijnMurphy_Fangohr2012 k parameterisation
-# Setting both equal to 1.0 means that the total k will simply be a linear combination
-# These need to both be valid real numbers
-#
-kd_weighting = 1.0
-kb_weighting = 1.0
-
 # asymmetry switch for OceanFlux k paramterisation
 # default is 1.0 ie no asymmetry
-# the option above 'k_t_OceanFluxGHG =' must be set to 'yes' for this to be used
+# the option above 'kt_OceanFluxGHG =' must be set to 'yes' for this to be used
 #
 kb_asymmetry = 1.00
 

--- a/configs/takahashi09_validation.conf
+++ b/configs/takahashi09_validation.conf
@@ -20,6 +20,8 @@
 #	 <Mmm>	 - converted to three letter month abbreviation, e.g. Jan for January
 #    <MMM>	 - uppercase three letter month abbreviation, e.g. JAN
 #    <mmm>	 - lowercase three letter month abbreviation, e.g. jan
+#	 <DD>	 - two digit decimal representation of the day of the month, e.g. 01 for the 1st day of the month
+#	 <DDD>	 - three digit decimal representation of the day of the year, e.g. 123 for 3rd May (124 on a leap year)
 #
 # In addition to these tokens, filename patterns can be specified using ? and * which
 # follow the standard Unix glob behaviour.
@@ -34,6 +36,9 @@ src_home = fluxengine_src
 # Woolf et al., 2012.
 flux_calc = bulk
 
+# Daily temporal resolution switch. Setting to 'yes' will calculate the flux for each day in each month.
+# If using this option, as least some of your input data should be daily.
+daily_resolution = no
 
 # Sea surface temperature to use (valid options are 'yes' or 'no').
 # If only one is enabled the other will be derived according to, i.e.:
@@ -233,3 +238,5 @@ k_rain_nonlinear_h2012 = no
 # Output directory for the resultant netcdf files
 #
 output_dir = output/validate_takahashi09
+#output_structure = <YYYY>/<MM>/<DD>_<hh>.<mm>
+#output_file = fe_output_<YY>_<DDD>_<hh>.<mm>.nc

--- a/fluxengine_src/fe_core.py
+++ b/fluxengine_src/fe_core.py
@@ -783,11 +783,6 @@ class FluxEngine:
                 logger.setLevel(logging.DEBUG);
         except:
             print "\n%s Couldn't initialise logger at path %s" % (function, runParams.LOG_PATH);
-    
-        if DEBUG:
-           print "\n%s Flux model: %d, k_parmaterisation: %d" % (function, runParams.flux_calc, runParams.k_parameterisation);
-           print "\n%s Using the following files %s (sstskin), %s (sstfnd) %s (windu10) %s (sal) %s (rain) %s (bio) %s (sstgrad)" % (function, runParams.sstskin_infile, runParams.sstfnd_infile, runParams.windu10_infile, runParams.salinity_infile, runParams.rain_infile, runParams.biology_infile, runParams.sstgrad_infile);
-           print "\n%s Using the following products %s (sstskin), %s (sstfnd) %s (windu10) %s (msl) %s (sal) %s (rain) %s (bio) %s (sstgrad)" % (function, runParams.sstskin_prod, runParams.sstfnd_prod, runParams.windu10_prod, runParams.pressure_prod, runParams.salinity_prod, runParams.rain_prod, runParams.biology_prod, runParams.sstgrad_prod);
         
         #TODO: Replace directly with self.nx, self.ny, no need to use local variables here.
         nx = self.nx;

--- a/fluxengine_src/fe_core.py
+++ b/fluxengine_src/fe_core.py
@@ -843,6 +843,7 @@ class FluxEngine:
         self.add_empty_data_layer("pco2_sw_cor");
         
         #apply additive saline skin value, but why selectively apply it?
+        #TODO: Why are these hard-coded values. Should be using minBound and maxBound?
         self.add_empty_data_layer("salinity_skin");
         for i in arange(self.nx * self.ny):
             if (self.data["salinity"].fdata[i] >= 0.0) and (self.data["salinity"].fdata[i] <= 50.0):
@@ -1067,38 +1068,7 @@ class FluxEngine:
         #########################################################
          
         # pCO2/fCO2 extrapolation (if turned on) from reference year
-        pco2_increment = (runParams.year - runParams.pco2_reference_year) * runParams.pco2_annual_extrapolation;
-        
-#        # if runParams.pco2_data_selection == 1, then using SOCAT data so no increment is added as SOCAT are normalised to 2010
-#        # if runParams.pco2_data_selection == 0, then using Takahashi et al data which are normalised to 2000
-#        if runParams.pco2_data_selection == 0:
-#        # increment to be added to pCO2w and pCO2a in Takahashi climatology
-#        # 1.5uatm per year since 2000 as set by Takahashi et al 2009.
-#        # Takahashi data are normalised to the year 2000
-#           pco2_increment = (runParams.year - 2000.0) * 1.5
-#           print "\n%s year: %d Takahashi pCO2_increment: %lf (uatm) (runParams.pco2_data_selection: %d)" % (function, runParams.year, pco2_increment,runParams.pco2_data_selection)
-#        elif (runParams.pco2_data_selection == 1): # signifies that SOCAT pco2 data are being used
-#           # need handling for SOCAT data for years before 2010
-#           # 1.5uatm per year since 2000 as set by Takahashi et al 2009.
-#           # so assuming -1.5uatm for each year prior to 2010
-#           pco2_increment = (runParams.year - 2010.0) * 1.5
-#           print "\n%s year: %d SOCAT pCO2_increment: %lf (uatm) (runParams.pco2_data_selection: %d)" % (function, runParams.year, pco2_increment,runParams.pco2_data_selection)
-#        elif (runParams.pco2_data_selection == 2): # signifies that SOCAT fco2 data are being used
-#           # need handling for SOCAT data for years before 2010
-#           # 1.5uatm per year since 2000 as set by Takahashi et al 2009.
-#           # so assuming -1.5uatm for each year prior to 2010
-#           pco2_increment = (runParams.year - 2010.0) * 1.5
-#           print "\n%s year: %d SOCAT fCO2_increment: %lf (uatm) (runParams.pco2_data_selection: %d)" % (function, runParams.year, pco2_increment,runParams.pco2_data_selection)
-#        elif (runParams.pco2_data_selection == 4): # signifies that in situ or time-series data are being used - no increment
-#           pco2_increment = 0.0
-#        elif (runParams.pco2_data_selection == 45): # signifies that SOCATv4 climatology is being used - increments apply
-#           pco2_increment = (runParams.year - 2010.0) * 1.5
-#           print "\n%s year: %d SOCATv4 climatology fCO2_increment: %lf (uatm) (runParams.pco2_data_selection: %d)" % (function, runParams.year, pco2_increment,runParams.pco2_data_selection)
-#        elif (runParams.pco2_data_selection == 3): # signifies that in situ or time-series data are being used - no increment
-#           pco2_increment = 0.0
-#           print "\ng%s year: %d insitu fCO2_increment: %lf (uatm) (runParams.pco2_data_selection: %d)" % (function, runParams.year, pco2_increment,runParams.pco2_data_selection)
-#        else:
-#           pco2_increment = 0.0
+        pco2_increment = (runParams.year - runParams.pco2_reference_year) * runParams.pco2_annual_correction;
             
         DeltaT_fdata = array([missing_value] * nx*ny)
         
@@ -1373,6 +1343,7 @@ class FluxEngine:
               self.data["conca"].fdata[i] = ((self.data["solubility_skin"].fdata[i] * conc_factor) * self.data["pco2_air_cor"].fdata[i])
               
               #flux calculation
+              #TODO: This is partially K-parameterisation dependent. Need to decouple this...
               if ((runParams.kb_asymmetry != 1.0) and (runParams.k_parameterisation == 3)):
                  kd_component = self.data["kd"].fdata[i] * k_factor
                  kb_component = self.data["kb"].fdata[i] * k_factor

--- a/fluxengine_src/fe_core.py
+++ b/fluxengine_src/fe_core.py
@@ -1459,6 +1459,7 @@ class FluxEngine:
         # write out results
         #        
         #Temp refactoring:
+        #TODO: Remove this and test.
         for name in ["krain", "kt", "kb", "kd"]:
             if name not in self.data:
                 self.add_empty_data_layer(name);

--- a/fluxengine_src/fe_core.py
+++ b/fluxengine_src/fe_core.py
@@ -1460,9 +1460,9 @@ class FluxEngine:
         #        
         #Temp refactoring:
         #TODO: Remove this and test.
-        for name in ["krain", "kt", "kb", "kd"]:
-            if name not in self.data:
-                self.add_empty_data_layer(name);
+#        for name in ["krain", "kt", "kb", "kd"]:
+#            if name not in self.data:
+#                self.add_empty_data_layer(name);
         
         #write out the final ouput to netcdf
         write_netcdf(self);

--- a/fluxengine_src/fe_core.py
+++ b/fluxengine_src/fe_core.py
@@ -36,6 +36,8 @@ from datalayer import DataLayer, DataLayerMetaData;
 from settings import Settings;
 from debug_tools import calc_mean; #calculate mean ignoring missing values.
 
+from datetime import timedelta;
+
  # debug mode switches
 DEBUG = False
 DEBUG_PRODUCTS = True
@@ -263,6 +265,11 @@ def write_netcdf(fluxEngineObject, verbose=False):
         if paramValue is not None:
             if type(paramValue) is bool: #netCDF does not support bool types.
                 paramValue = int(paramValue);
+            elif isinstance(paramValue, timedelta): #netCDF does not support object instances.
+                paramValue = str(paramValue);
+            elif paramValue == None: #netCDF does not support None type.
+                paramValue = "None";
+            
             setattr(ncfile, paramName, paramValue);
  
     ncfile.close();

--- a/fluxengine_src/fe_core.py
+++ b/fluxengine_src/fe_core.py
@@ -1316,6 +1316,9 @@ class FluxEngine:
         self.add_empty_data_layer("concw");
         self.add_empty_data_layer("conca");
         self.add_empty_data_layer("FKo07");
+        
+        #Update FH06 (OF/gas flux data layer) descritpion to reflect the gas transfer velocity calculation used in the calculation.
+        self.data["FH06"].longName = self.data["FH06"].longName % self.data["k"].name;
 
         #If using rain wet deposition, calculate the gas solubility in distilled water
         if runParams.rain_wet_deposition_switch:
@@ -1463,6 +1466,7 @@ class FluxEngine:
 #        for name in ["krain", "kt", "kb", "kd"]:
 #            if name not in self.data:
 #                self.add_empty_data_layer(name);
+        
         
         #write out the final ouput to netcdf
         write_netcdf(self);

--- a/fluxengine_src/fe_setup_tools.py
+++ b/fluxengine_src/fe_setup_tools.py
@@ -214,9 +214,7 @@ def verify_config_variables(configVariables, metadata, verbose=False):
     
     if (configVariables["use_sstskin"]==True) and ("sstskin_path" not in configVariables):
         raise ValueError("%s: use_sstskin is set but no sstskin inputfile (sstskin_path) was specified in the config file." % function);
-    
-    if (configVariables["sst_gradients"]==True) and ("sstgrad_path" not in configVariables):
-        raise ValueError("%s: use_gradients is set but no sstgrad inputfile (sstgrad_path) was specified in the config file: " % function);
+
 
 #Substitutes month/year tokens to create a valid glob.
 #Returns the a tuple containing (searchDirectory, fileGlob)
@@ -464,7 +462,7 @@ def run_fluxengine(configFilePath, yearsToRun, monthsToRun, verbose=False, proce
                    takahashiDriver=False, pco2DirOverride=None, outputDirOverride=None):
     function = inspect.stack()[0][1]+", "+inspect.stack()[0][3];
     hostname = socket.gethostname();
-    rootPath = path.dirname(path.dirname(inspect.stack()[0][1]));
+    rootPath = path.abspath(path.join(__file__, "../.."));
     if verbose:
         print "Hostname identified as: ", hostname;
         print "Working directory is: ", rootPath;
@@ -474,7 +472,7 @@ def run_fluxengine(configFilePath, yearsToRun, monthsToRun, verbose=False, proce
     configVariables = read_config_file(configPath, verbose=verbose);
     
     #Parse settings file for default metadata about the config variables
-    settingsPath = path.join(rootPath, configVariables["src_home"], "settings.xml");
+    settingsPath = path.join(rootPath, "fluxengine_src", "settings.xml");
     metadata = read_config_metadata(settingsPath, verbose=verbose);
     
     

--- a/fluxengine_src/fe_setup_tools.py
+++ b/fluxengine_src/fe_setup_tools.py
@@ -17,7 +17,9 @@ import inspect;
 import time;
 import socket; #for gethostname
 import calendar;
+from datetime import date, timedelta, datetime;
 import fnmatch; #matching file globs
+from numpy import cumsum;
 
 import fe_core as fluxengine
 import rate_parameterisation as k_params; #This is where k parameterisation logic is kept.
@@ -201,6 +203,19 @@ def verify_config_variables(configVariables, metadata, verbose=False):
             if varName[0:-4]+"prod" not in configVariables:
                 raise ValueError("%s: DataLayer path is specified (%s) but there is no corresponding prod. '%s' must be also be defined in the configuration file." % (function, varName, varName[0:-4]+"prod"));
     
+    #TODO: add datetime data type to settings.xml?
+    #deltatime is a special case
+    #Parse delta time config attribute
+    try:
+        tmpTime = datetime.strptime(configVariables["temporal_resolution"], "%d %H:%M");
+        configVariables["temporal_resolution"] = timedelta(days=tmpTime.day, hours=tmpTime.hour, minutes=tmpTime.minute);
+        if verbose:
+            print "Temporal resolution set to: ", configVariables["temporal_resolution"];
+    except ValueError:
+        if verbose:
+            print "Temporal resolution has been set to default (monthly)";
+        configVariables["temporal_resolution"] = None;
+    
     #Now process custom vars. Try to convert them to a float, but if they fail assume they're supposed to be a string.
     for varName in customVars:
         try:
@@ -216,21 +231,34 @@ def verify_config_variables(configVariables, metadata, verbose=False):
         raise ValueError("%s: use_sstskin is set but no sstskin inputfile (sstskin_path) was specified in the config file." % function);
 
 
-#Substitutes month/year tokens to create a valid glob.
-#Returns the a tuple containing (searchDirectory, fileGlob)
-def generate_glob(globSig, year, monthNum):
-    glob = globSig;
-    glob = glob.replace("<YYYY>", str(year));
-    glob = glob.replace("<YY>", str(year)[-2:]);
-    glob = glob.replace("<MM>", "%02d"%(monthNum+1));
-    glob = glob.replace("<MMM>", calendar.month_abbr[monthNum+1].upper());
-    glob = glob.replace("<Mmm>", calendar.month_abbr[monthNum+1]);
-    glob = glob.replace("<mmm>", calendar.month_abbr[monthNum+1].lower());
+#Substitutes various time tokens into the input string.
+#Does not modify the original arguments.
+#Accounts for leap years correctly.
+#curDatetime should be a datetime object.
+def substitute_tokens(inputStr, curDatetime):
+    year = curDatetime.year;
+    month = curDatetime.month;
+    day = curDatetime.day;
+    hour = curDatetime.hour;
+    minute = curDatetime.minute;
+
+    outputStr = inputStr;
+    outputStr = outputStr.replace("<YYYY>", str(year));
+    outputStr = outputStr.replace("<YY>", str(year)[-2:]);
+    outputStr = outputStr.replace("<MM>", "%02d"%(month));
+    outputStr = outputStr.replace("<MMM>", calendar.month_abbr[month].upper());
+    outputStr = outputStr.replace("<Mmm>", calendar.month_abbr[month]);
+    outputStr = outputStr.replace("<mmm>", calendar.month_abbr[month].lower());
+    outputStr = outputStr.replace("<DD>", "%02d"%day); #<DD> day of the month
+        
+    #<DDD> day of the year
+    cumulativeDaysByMonth = [0] + list(cumsum([calendar.monthrange(year, m)[1] for m in range(1,12)])); #Cumulative days in each month of the year (accounting for leap years)
+    outputStr = outputStr.replace("<DDD>", "%03d"%(day+cumulativeDaysByMonth[month-1])); #Day number in year, starting at 1 (up to 365 or 366 on leap years)
     
-    #glob.rsplit("/", 1);
-    #print "Split result:", glob;
-    
-    return (path.dirname(glob), path.basename(glob));
+    outputStr = outputStr.replace("<hh>", "%02d"%hour); #<hh> hours in 24 hour time.
+    outputStr = outputStr.replace("<mm>", "%02d"%minute) #<mm> mintue past the hour
+
+    return outputStr;
 
 
 #Returns a list of filepaths which match a glob
@@ -253,13 +281,13 @@ def match_filenames(givenPath, glob):
 #Converts between inconsistencies in the config file naming convention and FluxEngine nameing convention, e.g.:
 #   path -> infile
 #   appending _switch to bool variables
-def create_run_parameters(configVariables, varMetadata, year, monthNum, processTimeStr, configFile, processIndicatorLayersOff):
+def create_run_parameters(configVariables, varMetadata, curTimePoint, processTimeStr, configFile, processIndicatorLayersOff):
     function = inspect.stack()[0][1]+", "+inspect.stack()[0][3];
     
     runParams = {};
     #Copy over misc. parameters
     #runParams["year"] = 2000 if clArgs.use_takahashi_validation==True else runParams["year"] = year;
-    runParams["year"] = year;
+    runParams["year"] = curTimePoint.year;
     runParams["hostname"] = socket.gethostname();
     runParams["config_file"] = configFile;
     runParams["src_home"] = configVariables["src_home"];
@@ -274,17 +302,19 @@ def create_run_parameters(configVariables, varMetadata, year, monthNum, processT
         #DataLayerPaths: These can change based on month and year.
         if varName in varMetadata:
             if varMetadata[varName]["type"] == varMetadata[varName]["type"] == "DataLayerPath":
-                curPath, curGlob = generate_glob(configVariables[varName], year, monthNum);
+                pathGlob = substitute_tokens(configVariables[varName], curTimePoint); #substitute time tokens into the path/glob
+                curDir = path.dirname(pathGlob); #Directory to search in.
+                curGlob = path.basename(pathGlob); #File glob to match against.
                 #print "path:", curPath
                 #print "glob:", curGlob;
                 try:
-                    matches = match_filenames(curPath, curGlob);
+                    matches = match_filenames(curDir, curGlob);
                     matches = [match for match in matches if match.rsplit('/', 1)[-1][0] != '.']; #Remove hidden metadata files created by MACOS on some file systems. Required if sharing folders between MACOS and LINUX/WINDOWS.
                     
                     #If there's exactly one match for the file glob, add the data layer.
                     if len(matches) == 1: #Store the file path.
                         dataLayerName = varName[0:-5];
-                        runParams[dataLayerName+"_infile"] = path.join(curPath, matches[0]);
+                        runParams[dataLayerName+"_infile"] = path.join(curDir, matches[0]);
                         runParams[dataLayerName+"_prod"] = configVariables[dataLayerName+"_prod"];
                         runParams[dataLayerName+"_stddev_prod"] = configVariables[dataLayerName+"_stddev_prod"] if dataLayerName+"_stddev_prod" in configVariables else None;
                         runParams[dataLayerName+"_count_prod"] = configVariables[dataLayerName+"_count_prod"] if dataLayerName+"_count_prod" in configVariables else None;
@@ -295,9 +325,9 @@ def create_run_parameters(configVariables, varMetadata, year, monthNum, processT
                             runParams[dataLayerName+"_preprocessing"] = "no_preprocessing";
                         
                     else: #There isn't exactly 1 matching file, so we have a problem, add it to the list.
-                        missingFiles.append( (varName, path.join(curPath, curGlob) ) );
+                        missingFiles.append( (varName, path.join(curDir, curGlob) ) );
                 except Exception as e:
-                    print "Invalid filepath when checking for %s: %s" % (varName, curPath);
+                    print "Invalid filepath when checking for %s: %s" % (varName, curDir);
                     print type(e), e.args;
                     return None;
         
@@ -321,16 +351,13 @@ def create_run_parameters(configVariables, varMetadata, year, monthNum, processT
             return None;
             
 
-    #Output file
-    outFile = "OceanFluxGHG-month%02d-%s-%d-v0.nc" % (monthNum+1, calendar.month_abbr[monthNum+1].lower(), year);
-#    if clArgs.use_takahashi_validation==True:
-#        ##TODO: This needs to be corrected by passing "start_year 2000 end_year 2000" in the command line arguments once the correct ice and pressure data are being used.
-#        outDir = path.join(configVariables["output_dir"], str(2000), "%02d"%(monthNum+1));
-#    else:
-    outDir = path.join(configVariables["output_dir"], str(year), "%02d"%(monthNum+1));
+    #Output file/path
+    outputRoot = configVariables["output_dir"];
+    outputStructure = substitute_tokens(configVariables["output_structure"], curTimePoint);
+    outputFile = substitute_tokens(configVariables["output_file"], curTimePoint);
 
-    runParams["output_dir"] = outDir;
-    runParams["output_path"] = path.join(outDir, outFile);
+    runParams["output_dir"] = path.join(outputRoot, outputStructure); #root output directory
+    runParams["output_path"] = path.join(outputRoot, outputStructure, outputFile);
     
     
     return runParams;
@@ -457,9 +484,53 @@ def fe_obj_from_run_parameters(runParameters, metadata, processLayersOff=True, v
     
     return fe;
 
+#Takes a string start date and a string end date and returns a list of date objects between them (inclusive of start and end)
+#deltaTime is a datetime.deltatime object which specifies the interval between timepoints. If set to None then intervals will be monthly.
+#singleDate returns a list containing only the first date (used for testing).
+#Valid date/time string formats: YYYY, YYYY-MM-DD, YYYY-MM-DD hh:mm
+def generate_datetime_points(startStr, endStr, deltaTime=None, singleDate=False):
+    #Parse start/end date strings
+    try: #Parsing start date string
+        startYear = int(startStr);
+        startDate = datetime(startYear, 1, 1);
+    except ValueError: #startStr is not a single year, so try it as a datetime string
+        try:
+            startDate = datetime.strptime(startStr, "%Y-%m-%d %H:%M");
+        except ValueError: #startStr is not a single year, so try it as a date string (with no time component)
+            startDate = datetime.strptime(startStr, "%Y-%m-%d");
+    
+    try: #Parsing end date string
+        endYear = int(endStr);
+        endDate = datetime(endYear, 12, 31);
+    except ValueError: #endStr is not a single year, so try it as a datetime string
+        try:
+            endDate = datetime.strptime(endStr, "%Y-%m-%d %H:%M");
+        except ValueError: #endStr is not a single year, so try it as a date string (with no time component)
+            endDate = datetime.strptime(endStr, "%Y-%m-%d");
+    
+    
+    if startDate > endDate:
+        raise ValueError("Start date (%s) is after end data (%s)." % (str(startDate), str(endDate)));
+    
+    #Create datetime objects for each date between the start and end dates.
+    timePoints = [];
+    currentDate = startDate;
+    while currentDate <= endDate:
+        timePoints.append(currentDate);
+        if deltaTime == None: #Increment by the number of days in the current month (taking into account leap years)
+            currentDate += timedelta(days=calendar.monthrange(currentDate.year, currentDate.month)[1]);
+        else: #Increment by deltatime
+            currentDate += deltaTime;
+
+    if singleDate: #Discard all other time points and just return the first one.
+        return [timePoints[0]];
+    else:
+        return timePoints;
+
+
 #Takes a config file, a list of years and months, and runs the flux engine for each month/year combination.
-def run_fluxengine(configFilePath, yearsToRun, monthsToRun, verbose=False, processLayersOff=True,
-                   takahashiDriver=False, pco2DirOverride=None, outputDirOverride=None):
+def run_fluxengine(configFilePath, startDate, endDate, singleRun=False, verbose=False, processLayersOff=True,
+                   takahashiDriver=False, pco2DirOverride=None, outputDirOverride=None, dailyResolution=False):
     function = inspect.stack()[0][1]+", "+inspect.stack()[0][3];
     hostname = socket.gethostname();
     rootPath = path.abspath(path.join(__file__, "../.."));
@@ -474,7 +545,6 @@ def run_fluxengine(configFilePath, yearsToRun, monthsToRun, verbose=False, proce
     #Parse settings file for default metadata about the config variables
     settingsPath = path.join(rootPath, "fluxengine_src", "settings.xml");
     metadata = read_config_metadata(settingsPath, verbose=verbose);
-    
     
     #Substitute commandline override arguments (-pco2_dir_override, -output_dir_override)
     if (pco2DirOverride != None):
@@ -507,53 +577,56 @@ def run_fluxengine(configFilePath, yearsToRun, monthsToRun, verbose=False, proce
     processTimeStr = time.strftime("%d/%m/%Y %H:%M:%S");
     print "Executing on '%s' at %s" % (hostname, processTimeStr);
     
-    for year in yearsToRun:
-        for monthNum in monthsToRun:
-            #Run parameters can vary depending on the current month and year (e.g. paths and filenames,
-            #So these must be generated on a per-month/year basis.
-            try:
-                runParameters = create_run_parameters(configVariables, metadata, year, monthNum, processTimeStr, configFilePath, processLayersOff);
-                
-                #TODO: temporary stop-gap. Takahashi driver switch will be removed from future releases and moved to the configuration file.
-                if takahashiDriver == True:
-                    runParameters["TAKAHASHI_DRIVER"] = True;
-                else:
-                    runParameters["TAKAHASHI_DRIVER"] = False;
-            except ValueError as e:
-                print e.args;
-                return;
-            except OSError as e:
-                print e.args;
-                return;
+    #Generate a list of datetime objects overwhich to run the simulations
+    timePoints = generate_datetime_points(startDate, endDate, deltaTime=configVariables["temporal_resolution"], singleDate=singleRun);
+    #print "num timepoints:", len(timePoints);
+    #input("key to continue...");
+    for timePoint in timePoints:
+        #Run parameters can vary depending on the current month and year (e.g. paths and filenames,
+        #So these must be generated on a per-month/year basis.
+        try:
+            runParameters = create_run_parameters(configVariables, metadata, timePoint, processTimeStr, configFilePath, processLayersOff);
             
-            #Create output file path
-            try:
-                if path.exists(runParameters["output_dir"]) == False:
-                    makedirs(runParameters["output_dir"]);
-            except OSError as e:
-                print "Couldn't create output directory '%s'. Do you have write access?" % runParameters["output_dir"];
-                print type(e), e.args;
-            
-            #Create fluxengine object setup according to runParameters
-            fe = fe_obj_from_run_parameters(runParameters, metadata, processLayersOff, verbose=False);
-            
-            #Run fluxengine            
-            if fe != None:
-                #try:
-                    returnCode = fe.run();
-                #except Exception as e:
-                #    print "\n\n%s: Exception caught while running FluxEngine:" % function;
-                #    print type(e), e.args;
-                #    return 1;
-            
-            #Check for successful run, if one fails don't run the rest.
-            if returnCode != 0:
-                print ("%s: There was an error running flux engine:\n\n"%function), e.args[0];
-                print "Exiting...";
-                return (returnCode, fe);
+            #TODO: temporary stop-gap. Takahashi driver switch will be removed from future releases and moved to the configuration file.
+            if takahashiDriver == True:
+                runParameters["TAKAHASHI_DRIVER"] = True;
             else:
-                print "Flux engine exited with exit code:", returnCode;
-                print calendar.month_abbr[monthNum+1], year, "completed successfully.\n";
+                runParameters["TAKAHASHI_DRIVER"] = False;
+        except ValueError as e:
+            print e.args;
+            return;
+        except OSError as e:
+            print e.args;
+            return;
+        
+        #Create output file path
+        try:
+            if path.exists(runParameters["output_dir"]) == False:
+                makedirs(runParameters["output_dir"]);
+        except OSError as e:
+            print "Couldn't create output directory '%s'. Do you have write access?" % runParameters["output_dir"];
+            print type(e), e.args;
+        
+        #Create fluxengine object to use runParameters
+        fe = fe_obj_from_run_parameters(runParameters, metadata, processLayersOff, verbose=False);
+        
+        #Run fluxengine            
+        if fe != None:
+            #try:
+                returnCode = fe.run();
+            #except Exception as e:
+            #    print "\n\n%s: Exception caught while running FluxEngine:" % function;
+            #    print type(e), e.args;
+            #    return 1;
+        
+        #Check for successful run, if one fails don't run the rest.
+        if returnCode != 0:
+            print ("%s: There was an error running flux engine:\n\n"%function), e.args[0];
+            print "Exiting...";
+            return (returnCode, fe);
+        else:
+            print "Flux engine exited with exit code:", returnCode;
+            print "%d02"%timePoint.day, calendar.month_abbr[timePoint.month], timePoint.year, "completed successfully.\n";
             
     #runStatus = {};
     #runStatus["return_code"] = returnCode;

--- a/fluxengine_src/rate_parameterisation.py
+++ b/fluxengine_src/rate_parameterisation.py
@@ -40,7 +40,7 @@ def OceanFluxGHG_k(sigma0_fdata, sig_wv_ht_fdata, windu10_fdata, windu10_moment2
    kd_fdata = array([DataLayer.missing_value] * nx*ny)
    kb_fdata = array([DataLayer.missing_value] * nx*ny)
    
-   for i in arange(nx * ny):   
+   for i in arange(nx * ny):
 
       # kinematic viscosity
      if ( (sstskinC_fdata[i] != DataLayer.missing_value) ):        
@@ -91,6 +91,9 @@ def OceanFluxGHG_k(sigma0_fdata, sig_wv_ht_fdata, windu10_fdata, windu10_moment2
                 
    return kd_fdata, kb_fdata
 
+# kb_weighting and kd_weighting: Weighting for kb and kd components of k_GoddijnMurphy_Fangohr2012 k parameterisation
+# Setting both equal to 1.0 means that the total k will simply be a linear combination
+# These need to both be valid real numbers
 def OceanFluxGHG_kt(kd_fdata, kb_fdata, nx, ny, kb_weighting, kd_weighting):
    #combining the Oceanflux kd and kb components
    ktotal_fdata = array([DataLayer.missing_value] * nx * ny)
@@ -133,9 +136,9 @@ class KCalculationBase:
 class k_example(KCalculationBase):
     #Optional initialiser arguments can be used, but their names must correspond to names in the config file.
     #For example k_generic_sc is used here.
-    def __init__(self, k_generic_sc):
+    def __init__(self, example_init_parameter):
         self.name = self.__class__.__name__;
-        self.k_generic_sc = k_generic_sc;
+        self.parameter = example_init_parameter; #'example_init_parameter' would need to be defined in the configuration file
     
     #Must return a list of strings corresponding to the input data layers required by the k calculations. These must already exist.
     def input_names(self):
@@ -253,6 +256,7 @@ class k_Nightingale2000(KCalculationBase):
                 self.k[i] = DataLayer.missing_value
         
         return True;
+
 
 
 class kt_OceanFluxGHG(KCalculationBase):
@@ -653,7 +657,7 @@ class KCalculationExtension:
 #add ho1997 value to data from chosen k parameterisation (adds rain component to the results from the existing choice of parameterisation)
 #see Ashton2016
 #note: data are filtered based on windu10 to ensure that they cover the same data as the wind based paramterisations 
-class AddKRainLinearHo19997(KCalculationExtension):
+class AddKRainLinearHo1997(KCalculationExtension):
     def __init__(self):
         self.name = self.__class__.__name__;
     

--- a/fluxengine_src/rate_parameterisation.py
+++ b/fluxengine_src/rate_parameterisation.py
@@ -96,7 +96,7 @@ def OceanFluxGHG_k(sigma0_fdata, sig_wv_ht_fdata, windu10_fdata, windu10_moment2
 # These need to both be valid real numbers
 def OceanFluxGHG_kt(kd_fdata, kb_fdata, kb_weighting, kd_weighting):
    #combining the Oceanflux kd and kb components
-   dataLength = len(dk_fdata);
+   dataLength = len(kd_fdata);
    ktotal_fdata = array([DataLayer.missing_value] * dataLength)
    for i in arange(dataLength):  
        # summing the results

--- a/fluxengine_src/rate_parameterisation.py
+++ b/fluxengine_src/rate_parameterisation.py
@@ -151,7 +151,7 @@ class k_example(KCalculationBase):
     #Main k calculation. Input and output datalayers can be extracted from 'data'.
     #Should modify output layers in place (i.e. without copying), and return True or False to indicate successful execution.
     def __call__(self, data):
-        print self.long_name, "with k_generic_sc as", self.k_generic_sc;
+        print self.name, "with k_generic_sc as", self.k_generic_sc;
         return True;
 
 
@@ -202,7 +202,7 @@ class k_Ho2006(KCalculationBase):
             for name in self.input_names() + self.output_names():
                 setattr(self, name, data[name].fdata);
             data["k"].standardName="gas_transfer_velocity_of_carbon_dioxide";
-            data["k"].long_name="Ho et al., 2006 (H06) gas transfer velocity";
+            data["k"].longName="Ho et al., 2006 (H06) gas transfer velocity";
             
         except KeyError as e:
             print "%s: Required data layer for selected k parameterisation was not found." % function;
@@ -280,8 +280,8 @@ class kt_OceanFluxGHG(KCalculationBase):
             #for ease of access, simply assign attributes to each input/output.
             for name in self.input_names() + self.output_names():
                 setattr(self, name, data[name].fdata);
-            data["k"].standard_name = "total (direct_from_backscatter plus bubble mediated) component of gas transfer velocity of carbon dioxide";
-            data["k"].long_name = "total (direct_from_backscatter plus bubble mediated) component of gas transfer velocity of carbon dioxide";
+            data["k"].standardName = "total (direct_from_backscatter plus bubble mediated) component of gas transfer velocity of carbon dioxide";
+            data["k"].longName = "total (direct_from_backscatter plus bubble mediated) component of gas transfer velocity of carbon dioxide";
         except KeyError as e:
             print "%s: Required data layer for selected k parameterisation was not found." % function;
             print type(e), e.args;

--- a/fluxengine_src/rate_parameterisation.py
+++ b/fluxengine_src/rate_parameterisation.py
@@ -29,18 +29,18 @@ def GM12_kd_wind(windu10_fdata, windu10_moment2_fdata, windu10_moment3_fdata, sc
       
     return kdwind_fdata
 
-def OceanFluxGHG_k(sigma0_fdata, sig_wv_ht_fdata, windu10_fdata, windu10_moment2_fdata, sstskinC_fdata, nx, ny, pco2_sw_fdata, scskin_fdata):
-    
+def OceanFluxGHG_k(sigma0_fdata, sig_wv_ht_fdata, windu10_fdata, windu10_moment2_fdata, sstskinC_fdata,  pco2_sw_fdata, scskin_fdata):
+   dataLength = len(sigma0_fdata);
     # determine the combined Goddijn-Murphy 2012 and Fangohr and Woolf parameterisation
-   kinematic_fdata = array([DataLayer.missing_value] * nx*ny)
-   CD_fdata = array([DataLayer.missing_value] * nx*ny)
-   friction_fdata = array([DataLayer.missing_value] * nx*ny)
+   kinematic_fdata = array([DataLayer.missing_value] * dataLength)
+   CD_fdata = array([DataLayer.missing_value] * dataLength)
+   friction_fdata = array([DataLayer.missing_value] * dataLength)
    
    #kt_fdata = array([missing_value] * nx*ny) #TMH: This doens't appear to be used...
-   kd_fdata = array([DataLayer.missing_value] * nx*ny)
-   kb_fdata = array([DataLayer.missing_value] * nx*ny)
+   kd_fdata = array([DataLayer.missing_value] * dataLength)
+   kb_fdata = array([DataLayer.missing_value] * dataLength)
    
-   for i in arange(nx * ny):
+   for i in arange(dataLength):
 
       # kinematic viscosity
      if ( (sstskinC_fdata[i] != DataLayer.missing_value) ):        
@@ -48,7 +48,7 @@ def OceanFluxGHG_k(sigma0_fdata, sig_wv_ht_fdata, windu10_fdata, windu10_moment2
         kinematic_fdata[i] = 0.00000183 * exp( (-(sstskinC_fdata[i])) / 36.0)
      else:
         kinematic_fdata[i] = DataLayer.missing_value
-     pco2_sw_fdata.shape = (nx, ny)
+     pco2_sw_fdata.shape = (dataLength)
 
       # wind drag coefficient
       # algorithm is only value for a wind speed of up to 26 ms^-1
@@ -94,10 +94,11 @@ def OceanFluxGHG_k(sigma0_fdata, sig_wv_ht_fdata, windu10_fdata, windu10_moment2
 # kb_weighting and kd_weighting: Weighting for kb and kd components of k_GoddijnMurphy_Fangohr2012 k parameterisation
 # Setting both equal to 1.0 means that the total k will simply be a linear combination
 # These need to both be valid real numbers
-def OceanFluxGHG_kt(kd_fdata, kb_fdata, nx, ny, kb_weighting, kd_weighting):
+def OceanFluxGHG_kt(kd_fdata, kb_fdata, kb_weighting, kd_weighting):
    #combining the Oceanflux kd and kb components
-   ktotal_fdata = array([DataLayer.missing_value] * nx * ny)
-   for i in arange(nx * ny):  
+   dataLength = len(dk_fdata);
+   ktotal_fdata = array([DataLayer.missing_value] * dataLength)
+   for i in arange(dataLength):  
        # summing the results
        # units are in 10^-4 m/s
       if ( (kd_fdata[i] != DataLayer.missing_value) and (kb_fdata[i] != DataLayer.missing_value) ):
@@ -289,7 +290,7 @@ class kt_OceanFluxGHG(KCalculationBase):
         
         self.kd, self.kb = OceanFluxGHG_k(self.sigma0, self.sig_wv_ht, self.windu10, self.windu10_moment2, self.sstskinC, self.pco2_sw, self.scskin);
         # calculate the total kt
-        self.kt = OceanFluxGHG_kt(self.kd, self.kb, self.nx, self.ny, self.kb_weighting, self.kd_weighting);
+        self.kt = OceanFluxGHG_kt(self.kd, self.kb, self.kb_weighting, self.kd_weighting);
         self.k[:] = self.kt;
         
         return True;
@@ -592,7 +593,7 @@ class kt_OceanFluxGHG_kd_wind(KCalculationBase):
         
         #overwrite kd with Goddijn-Murphy et al., JGR 2012 gas transfer...
         self.kd = GM12_kd_wind(self.windu10, self.windu10_moment2, self.windu10_moment3, self.scskin, self.nx, self.ny);
-        self.kt = OceanFluxGHG_kt(self.kd, self.kb, self.nx, self.ny, self.kb_weighting, self.kd_weighting);
+        self.kt = OceanFluxGHG_kt(self.kd, self.kb, self.kb_weighting, self.kd_weighting);
         self.k[:] = self.kt
         return True;
 

--- a/fluxengine_src/settings.xml
+++ b/fluxengine_src/settings.xml
@@ -364,9 +364,6 @@
 		<Variable name="longitude_prod" required="true" type="string"></Variable>
 		<Variable name="time_prod" required="true" type="string"></Variable>
 
-		<Variable name="pco2_reference_year" required="true" type="float" default="2010"></Variable>
-		<Variable name="pco2_annual_extrapolation" required="true" type="float" default="0.0"></Variable>
-
 		<Variable name="pco2_data_selection" required="true" type="multioption">
 			<Option value="0" str="taka"></Option>
 			<Option value="1" str="socat_pco2"></Option>
@@ -386,13 +383,11 @@
 
 
 
-		<!-- These input datalayers are always required and each need a path and prod -->
+		<!-- These input datalayers are always required (I think?) and each need a path and prod -->
 		<Variable name="pco2_sw" required="true" type="DataLayer"></Variable>
 		<Variable name="vco2_air" required="true" type="DataLayer"></Variable>
 		<Variable name="pco2_sst" required="true" type="DataLayer"></Variable>
 		<Variable name="pco2_air" required="true" type="DataLayer"></Variable>
-		<Variable name="sstskin" required="false" type="DataLayer"></Variable>
-		<Variable name="sstfnd" required="false" type="DataLayer"></Variable>
 		<Variable name="windu10" required="true" type="DataLayer"></Variable>
 		<Variable name="sigma0" required="true" type="DataLayer"></Variable>
 		<Variable name="sig_wv_ht" required="true" type="DataLayer"></Variable>
@@ -401,7 +396,9 @@
 		<Variable name="pressure" required="true" type="DataLayer"></Variable>
 		<Variable name="salinity" required="true" type="DataLayer"></Variable>
 
-		<!-- These input datalayers are optional -->
+		<!-- These input datalayers are optional or only required for certain parameter options -->
+		<Variable name="sstskin" required="false" type="DataLayer"></Variable>
+		<Variable name="sstfnd" required="false" type="DataLayer"></Variable>
 		<Variable name="windu10_moment2" required="false" type="DataLayer"></Variable>
 		<Variable name="windu10_moment3" required="false" type="DataLayer"></Variable>
 		<Variable name="biology" required="false" type="DataLayer"></Variable>
@@ -436,6 +433,7 @@
 		<Variable name="bias_k_biology_value" required="true" type="float"></Variable>
 		<Variable name="bias_k_wind_value" required="true" type="float"></Variable>
 
+		<!--- kb vs kd weighting for 'equilibrium' flux model? -->
 		<Variable name="kd_weighting" required="true" type="float"></Variable>
 		<Variable name="kb_weighting" required="true" type="float"></Variable>
 		<Variable name="kb_asymmetry" required="true" type="float"></Variable>
@@ -445,13 +443,16 @@
 		<Variable name="k_rain_linear_ho1997" required="true" type="switch"></Variable>
 		<Variable name="k_rain_nonlinear_h2012" required="true" type="switch"></Variable>
 
-		<!-- These values are conditional on other values -->
+		<!-- These values are conditional on other values and/or have default values -->
 		<Variable name="saline_skin_value" required="false" type="float" default="0.0"></Variable>
 
 		<Variable name="GAS" required="false" type="string" default="CO2"></Variable>
 		<Variable name="ATMGAS" required="false" type="string" default="V"></Variable>
 		<Variable name="LOG_PATH" required="false" type="string" default="fluxengine.log"></Variable>
 		<Variable name="cool_skin_difference" required="false" type="float" default="-0.17"></Variable>
+
+		<Variable name="pco2_reference_year" required="true" type="float" default="2010"></Variable>
+		<Variable name="pco2_annual_extrapolation" required="true" type="float" default="0.0"></Variable>
 
 	</ConfigParameters>
 </Settings>

--- a/fluxengine_src/settings.xml
+++ b/fluxengine_src/settings.xml
@@ -421,6 +421,7 @@
 		<Variable name="bias_k_wind_value" required="true" type="float"></Variable>
 
 		<!-- These values are conditional on other values and/or have default values -->
+		<Variable name="temporal_resolution" required="false" type="string" default="monthly"></Variable> <!-- Valid formats are YYYY, YYYY-MM-DD, YYYY-MM-DD hh:mm, any other strings are interpretted as monthly -->
 		<Variable name="saline_skin_value" required="false" type="float" default="0.0"></Variable>
 
 		<Variable name="GAS" required="false" type="string" default="CO2"></Variable>
@@ -455,6 +456,10 @@
 		<Variable name="rain_wet_deposition" required="true" type="switch" default="no"></Variable>
 		<Variable name="k_rain_linear_ho1997" required="true" type="switch" default="no"></Variable>
 		<Variable name="k_rain_nonlinear_h2012" required="true" type="switch" default="no"></Variable>
+
+
+		<Variable name="output_structure" required="true" type="string" default="&lt;YYYY&gt;/&lt;MM&gt;"></Variable>
+		<Variable name="output_file" required="true" type="string" default="OceanFluxGHG-month&lt;MM&gt;-&lt;mmm&gt;-&lt;YYYY&gt;-v0.nc"></Variable>
 
 	</ConfigParameters>
 </Settings>

--- a/fluxengine_src/settings.xml
+++ b/fluxengine_src/settings.xml
@@ -173,7 +173,7 @@
 		<!--<DataLayer name="FH06" netCDFName="OF" units="g C m-2 day-1" minBound="-0.75" maxBound="0.6"-->
 		<DataLayer name="FH06" netCDFName="OF" units="g C m-2 day-1" minBound="-1000.0" maxBound="1000.0"
 			 standardName="air_to_sea_carbon_dioxide_flux"
-			 longName="Air-sea CO2 flux using the %s %s gas transfer velocity (k)">
+			 longName="Air-sea CO2 flux using the %s gas transfer velocity (k)">
 			 </DataLayer> <!-- Oddly minBoundmaxBound is overwritten in flux engine to -1000+1000 -->
 
 		<DataLayer name="kt" netCDFName="OK1" units="cm h-1" minBound="0.0" maxBound="100.0"

--- a/fluxengine_src/settings.xml
+++ b/fluxengine_src/settings.xml
@@ -413,35 +413,12 @@
 
 
 		<!-- these should be optional and/or moved to datalayer attributes: -->
-		<Variable name="random_noise_windu10" required="true" type="switch"></Variable>
-		<Variable name="random_noise_sstskin" required="true" type="switch"></Variable>
-		<Variable name="random_noise_sstfnd" required="true" type="switch"></Variable>
-		<Variable name="random_noise_pco2" required="true" type="switch"></Variable>
-
-		<Variable name="bias_windu10" required="true" type="switch"></Variable>
-		<Variable name="bias_windu10_value" required="true" type="float"></Variable>
-		<Variable name="bias_sstskin" required="true" type="switch"></Variable>
-		<Variable name="bias_sstskin_value" required="true" type="float"></Variable>
-		<Variable name="bias_sstfnd" required="true" type="switch"></Variable>
-		<Variable name="bias_sstfnd_value" required="true" type="float"></Variable>
-		<Variable name="bias_pco2" required="true" type="switch"></Variable>
-		<Variable name="bias_pco2_value" required="true" type="float"></Variable>
 
 		<Variable name="bias_k" required="true" type="switch"></Variable>
 		<Variable name="bias_k_percent" required="true" type="switch"></Variable>
 		<Variable name="bias_k_value" required="true" type="float"></Variable>
 		<Variable name="bias_k_biology_value" required="true" type="float"></Variable>
 		<Variable name="bias_k_wind_value" required="true" type="float"></Variable>
-
-		<!--- kb vs kd weighting for 'equilibrium' flux model? -->
-		<Variable name="kd_weighting" required="true" type="float"></Variable>
-		<Variable name="kb_weighting" required="true" type="float"></Variable>
-		<Variable name="kb_asymmetry" required="true" type="float"></Variable>
-
-		<Variable name="bias_sstskin_due_rain" required="true" type="switch"></Variable>
-		<Variable name="rain_wet_deposition" required="true" type="switch"></Variable>
-		<Variable name="k_rain_linear_ho1997" required="true" type="switch"></Variable>
-		<Variable name="k_rain_nonlinear_h2012" required="true" type="switch"></Variable>
 
 		<!-- These values are conditional on other values and/or have default values -->
 		<Variable name="saline_skin_value" required="false" type="float" default="0.0"></Variable>
@@ -452,10 +429,45 @@
 		<Variable name="cool_skin_difference" required="false" type="float" default="-0.17"></Variable>
 
 		<Variable name="pco2_reference_year" required="true" type="float" default="2010"></Variable>
-		<Variable name="pco2_annual_extrapolation" required="true" type="float" default="0.0"></Variable>
+		<Variable name="pco2_annual_correction" required="true" type="float" default="0.0"></Variable>
+
+		<Variable name="random_noise_windu10" required="true" type="switch" default="no"></Variable>
+		<Variable name="random_noise_sstskin" required="true" type="switch" default="no"></Variable>
+		<Variable name="random_noise_sstfnd" required="true" type="switch" default="no"></Variable>
+		<Variable name="random_noise_pco2" required="true" type="switch" default="no"></Variable>
+		<Variable name="bias_windu10" required="true" type="switch" default="no"></Variable>
+		<Variable name="bias_windu10_value" required="true" type="float" default="0.0"></Variable>
+		<Variable name="bias_sstskin" required="true" type="switch" default="no"></Variable>
+		<Variable name="bias_sstskin_value" required="true" type="float" default="0.0"></Variable>
+		<Variable name="bias_sstfnd" required="true" type="switch" default="no"></Variable>
+		<Variable name="bias_sstfnd_value" required="true" type="float" default="0.0"></Variable>
+		<Variable name="bias_pco2" required="true" type="switch" default="no"></Variable>
+		<Variable name="bias_pco2_value" required="true" type="float" default="0.0"></Variable>
+
+		<Variable name="kb_asymmetry" required="true" type="float" default="1.0"></Variable>
+
+		<Variable name="bias_sstskin_due_rain" required="true" type="switch" default="no"></Variable>
+		<Variable name="bias_sstskin_due_rain_value" required="true" type="float" default="0.0"></Variable>
+		<Variable name="bias_sstskin_due_rain_intensity" required="true" type="float" default="0.0"></Variable>
+		<Variable name="bias_sstskin_due_rain_wind" required="true" type="float" default="0.0"></Variable>
+
+
+		<Variable name="rain_wet_deposition" required="true" type="switch" default="no"></Variable>
+		<Variable name="k_rain_linear_ho1997" required="true" type="switch" default="no"></Variable>
+		<Variable name="k_rain_nonlinear_h2012" required="true" type="switch" default="no"></Variable>
 
 	</ConfigParameters>
 </Settings>
+
+<!-- known custom variables:
+		<Variable name="kd_weighting" required="false" type="float"></Variable>
+		<Variable name="kb_weighting" required="false" type="float"></Variable>
+		k_generic_sc
+		k_generic_a0
+		k_generic_a1
+		k_generic_a2
+		k_generic_a3
+-->
 
 <!--
 <DataLayer name="" netCDFName="" units="" minBound="0.0" maxBound="1500.0"

--- a/ofluxghg_run.py
+++ b/ofluxghg_run.py
@@ -44,26 +44,18 @@ if __name__ == "__main__":
                         action="store_true");
     clParser.add_argument("-use_takahashi_driver", "-t", help="indicates that this is a Takahashi validation run. This should only be used in conjunction with the supplied takahashi09_validation/conf file.",
                           action="store_true", default=False);
-    #clParser.add_argument("-use_takahashi_validation", "-t", help="DEPRECIATED: This is non-functional and should not be used. Instead use the takahashi validation configuration file provided in the 'configs' folder.",
-    #                    action="store_true");
     clParser.add_argument("-verbose", "-v", help="verbose: increases the amount of information sent to stdout.",
                         action="store_true");
-    clParser.add_argument("-year_start", "-s", metavar='\b', help="first year to evaluate (default=2010)", type=int, default=2010);
-    clParser.add_argument("-year_end", "-e", metavar='\b', help="final year to evaluate (default=2010)", type=int, default=2010);
+    #clParser.add_argument("-year_start", "-s", metavar='\b', help="first year to evaluate (default=2010)", type=int, default=2010);
+    clParser.add_argument("-start_date", "-s", metavar='\b', help="Flux calculation will be computed from this date (default = 01-01-2010 00:00).", type=str, default="01-01-2010 00:00");
+    clParser.add_argument("-end_date", "-e", metavar='\b', help="Flux calculation will be computed up to (and potentially including) this date (default = 31-12-2010 23:59).", type=str, default="31-12-2010 23:59");
     #clParser.add_argument("-list_k, help="...", action="store_true", default=False);
     #clParser.add_argument("-list_preprocessing", help="...", action="store_true", default=False);
-    clParser.add_argument("-m1", help="only run a single month (useful for testing).", action="store_true", default=False);
+    clParser.add_argument("-S1", help="only run a timepoint (e.g. a single month or single day depending on temporal resolution). This can be useful for testing.", action="store_true", default=False);
     clArgs = clParser.parse_args();
     
     
-    #Months and years to run the model over
-    yearsToRun = range(clArgs.year_start, clArgs.year_end+1);
-    monthsToRun = range(0,12);
-    if clArgs.m1 == True: #If m1 flag is set, just run the first month.
-        monthsToRun = [monthsToRun[0]];
-        yearsToRun = [yearsToRun[0]];
-    
-    returnCode, fe = setup.run_fluxengine(clArgs.config, yearsToRun, monthsToRun, verbose=clArgs.verbose,
+    returnCode, fe = setup.run_fluxengine(clArgs.config, clArgs.start_date, clArgs.end_date, singleRun=clArgs.S1, verbose=clArgs.verbose,
                    processLayersOff=clArgs.process_layers_off,
                    takahashiDriver=clArgs.use_takahashi_driver,
                    pco2DirOverride=clArgs.pco2_dir_override,

--- a/validate_socatv4_sst_salinity_gradients_N00.py
+++ b/validate_socatv4_sst_salinity_gradients_N00.py
@@ -27,13 +27,13 @@ def run_socat_sst_salinity_gradients_N00_validation(verbose=True):
     if verbose:
         print "Running FluxEngine for year 2010...";
     configFilePath = path.join(feRoot, "configs/socatv4_sst_salinity_gradients-N00.conf");
-    runStatus = run_fluxengine(configFilePath, [2010], range(0,12), processLayersOff=True, verbose=False);
+    runStatus = run_fluxengine(configFilePath, 2010, 2010, processLayersOff=True, verbose=False);
     
     
     #run net budgets
     if verbose:
         print "\n\nNow calculating flux budgets...";
-    outputFilePath = path.join("output", "validate_socatv4_sst_salinity_N00");
+    outputFilePath = path.join("output", "validate_socatv4_sst_salinity_N00", "");
     fluxBudgetsArgs = Namespace(LooseIce=False, cidataset='OIC1', cwdataset='OSFC',
                                 dir=path.join(feRoot, outputFilePath, ''), fluxdataset='OF', gridarea=0,
                                 gridareadataset='area', gridareafile='no_file', icePercent=False, icedataset='P1',

--- a/validate_socatv4_sst_salinity_gradients_N00.py
+++ b/validate_socatv4_sst_salinity_gradients_N00.py
@@ -33,7 +33,7 @@ def run_socat_sst_salinity_gradients_N00_validation(verbose=True):
     #run net budgets
     if verbose:
         print "\n\nNow calculating flux budgets...";
-    outputFilePath = "output/validate_socatv4_sst_salinity_N00/";
+    outputFilePath = path.join("output", "validate_socatv4_sst_salinity_N00");
     fluxBudgetsArgs = Namespace(LooseIce=False, cidataset='OIC1', cwdataset='OSFC',
                                 dir=path.join(feRoot, outputFilePath, ''), fluxdataset='OF', gridarea=0,
                                 gridareadataset='area', gridareafile='no_file', icePercent=False, icedataset='P1',
@@ -47,8 +47,8 @@ def run_socat_sst_salinity_gradients_N00_validation(verbose=True):
     #compare similarity flux budgets output between new and ref runs
     if verbose:
         print "\n\nComparing output to reference data...";
-    newPath = "output/validate_socatv4_sst_salinity_N00/_global.txt";
-    refPath = "data/validation_data/validation_reference_output/socatv4_sst_salinity_N00_reference_FEv2/SST_Salinity_gradients-N00_global.txt";
+    newPath = path.join("output", "validate_socatv4_sst_salinity_N00", "_global.txt");
+    refPath = path.join("data", "validation_data", "validation_reference_output", "socatv4_sst_salinity_N00_reference_FEv2", "SST_Salinity_gradients-N00_global.txt");
     diffs = calc_net_budget_percentages(newPath, refPath, verbose=False);
     
     numFailed = 0;

--- a/validate_takahashi09.py
+++ b/validate_takahashi09.py
@@ -26,13 +26,13 @@ def run_takahashi09_validation(verbose=True):
     if verbose:
         print "Running FluxEngine for year 2000 using takahashi09 validation";
     configFilePath = path.join("configs", "takahashi09_validation.conf");
-    runStatus = run_fluxengine(configFilePath, [2000], range(0,12), processLayersOff=True, takahashiDriver=True, verbose=False);
+    runStatus = run_fluxengine(configFilePath, 2000, 2000, processLayersOff=True, takahashiDriver=True, verbose=False);
     
     
     #run net budgets
     if verbose:
         print "\n\nNow calculating flux budgets...";
-    outputPath = path.join(feRoot, "output","validate_takahashi09");
+    outputPath = path.join(feRoot, "output","validate_takahashi09","");
     
     fluxBudgetsArgs = Namespace(LooseIce=False, cidataset='OIC1', cwdataset='OSFC', dir=outputPath,
                                 fluxdataset='OF', gridarea=0,

--- a/validate_takahashi09.py
+++ b/validate_takahashi09.py
@@ -25,20 +25,20 @@ def run_takahashi09_validation(verbose=True):
     #Run flux engine
     if verbose:
         print "Running FluxEngine for year 2000 using takahashi09 validation";
-    configFilePath = "configs/takahashi09_validation.conf";
+    configFilePath = path.join("configs", "takahashi09_validation.conf");
     runStatus = run_fluxengine(configFilePath, [2000], range(0,12), processLayersOff=True, takahashiDriver=True, verbose=False);
     
     
     #run net budgets
     if verbose:
         print "\n\nNow calculating flux budgets...";
-    outputPath = path.join(feRoot, "output/validate_takahashi09/")
+    outputPath = path.join(feRoot, "output","validate_takahashi09");
     
     fluxBudgetsArgs = Namespace(LooseIce=False, cidataset='OIC1', cwdataset='OSFC', dir=outputPath,
                                 fluxdataset='OF', gridarea=0,
                                 gridareadataset='area', gridareafile='no_file', icePercent=False, icedataset='P1',
-                                kwdataset='OK3', landdataset='land_proportion', landfile=path.join(feRoot, 'data/onedeg_land.nc'),
-                                maskdatasets=[], maskfile=path.join(feRoot, 'data/World_Seas-final-complete_IGA.nc'),
+                                kwdataset='OK3', landdataset='land_proportion', landfile=path.join(feRoot, "data", "onedeg_land.nc"),
+                                maskdatasets=[], maskfile=path.join(feRoot, "data", "World_Seas-final-complete_IGA.nc"),
                                 outroot=outputPath, places=10, ref=None,
                                 regions=[], verbosity=0, window=None);
     
@@ -77,7 +77,7 @@ def run_takahashi09_validation(verbose=True):
     #Test 2: Compare similarity of flux budgets to reference data for FEv1:
     if verbose:
         print "\n\nValidation Test 2) Comparing validation output to FluxEngine v1.0 output:";
-    refFEv1Path = path.join(feRoot, "data/validation_data/validation_reference_output/takahashi09_FEv1/", "_global.txt");
+    refFEv1Path = path.join(feRoot, "data","validation_data","validation_reference_output","takahashi09_FEv1", "_global.txt");
     diffsFEv1 = calc_net_budget_percentages(budgetsOutputFilePath, refFEv1Path, verbose=False);
     numFailed = 0;
     
@@ -101,7 +101,7 @@ def run_takahashi09_validation(verbose=True):
     #Test 3: Compare similarity of flux budgets to reference data for FEv2:
     if verbose:
         print "\n\nValidation Test 3) Comparing validation output to FluxEngine v2.0 output:";
-    refFEv2Path = path.join(feRoot, "data/validation_data/validation_reference_output/takahashi09_FEv2/", "_global.txt");
+    refFEv2Path = path.join(feRoot, "data","validation_data","validation_reference_output","takahashi09_FEv2", "_global.txt");
     diffsFEv2 = calc_net_budget_percentages(budgetsOutputFilePath, refFEv2Path, verbose=False);
     numFailed = 0;
     


### PR DESCRIPTION
New features:
*Specify temporal resolution in config
*Specify custom output file names and output directory structure
*Start and end dates can now also be specified as full dates (instead of just years). Use the following format: "YYYY-MM-DD" and "YYYY-MM-DD hh:mm". Back compatibility to "YYYY" format will use the first day of the year (for start_date) or the last day of the year (end_date).

Various small bug fixes.