### PR TITLE
Added flexibility for different file names and user-specified regioncodes

### DIFF
--- a/fluxengine_src/tools/reanalyse_socat/v2_f_conversion.py
+++ b/fluxengine_src/tools/reanalyse_socat/v2_f_conversion.py
@@ -74,11 +74,14 @@ def v2_f_conversion(jds, lons, lats, SST_Cs, sals, Teq_Cs, Ps, Peqs, sal_woas1, 
         fCO2_Tym - fCO2 recomputed for Tcl_C (uatm)
         qf - quality flag?"""
 
+   
    #Because this function changes the values of the sal_woas array we should copy it and change the copy instead
    sal_woas=sal_woas1.copy()
    # only use records where SST_Cs, fCO2_recs and Tcls are valid 
-   goodpoints=np.where((np.isfinite(SST_Cs)) & (np.isfinite(fCO2_recs)) & (Tcls > 0) & (Tcls < 1000) & (np.isfinite(Peq_cls)))# some Tcl data = 9.96921e+36 were found for ATS-ARC
-   badpoints=np.where(~(np.isfinite(SST_Cs)) | ~(np.isfinite(fCO2_recs)) | (Tcls > 1000) | ~(np.isfinite(Peq_cls)))
+   goodpoints=np.where((np.isfinite(SST_Cs)) & (np.isfinite(fCO2_recs)) & (Tcls >= 0) & (Tcls < 1000) & (np.isfinite(Peq_cls)))# some Tcl data = 9.96921e+36 were found for ATS-ARC
+   badpoints=np.where(~(np.isfinite(SST_Cs)) | ~(np.isfinite(fCO2_recs)) | (Tcls <0) | (Tcls >= 1000) | ~(np.isfinite(Peq_cls))) #TMH: updated so that good and bad points are mutually exclusive and the whole domain
+
+   
    if badpoints[0].size != 0:
       fileout=tempfile.mkstemp(prefix="%s/ignored_points_"%tempdir)[1]
       print "Writing ignored points to temp file: %s"%fileout

--- a/fluxengine_src/tools/reanalyse_socat_driver.py
+++ b/fluxengine_src/tools/reanalyse_socat_driver.py
@@ -11,7 +11,30 @@ import argparse;
 from os import path, makedirs;
 import shutil; ##move desired output from reanalyse_socat to the specified output folder and delete undesired output
 
-#TODO: 
+
+#Example options:
+#Single global input file, gridded output, no coastal file:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv4/ -socat_files SOCATv4.tsv -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles
+#Multiple regions, gridded output, no coastal file:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv4/ -socat_files SOCATv4_NorthAtlantic.tsv SOCATv4_Indian.tsv -regions NA IN -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles
+#Multiple regions, gridded output, with coastal file:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv4/ -socat_files SOCATv4_NorthAtlantic.tsv SOCATv4_Indian.tsv SOCATv4_Coastal.tsv -regions NA IN CO -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles -withcoastal CO
+#Multiple regions, ascii output, no coastal file:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv4/ -socat_files SOCATv4_NorthAtlantic.tsv SOCATv4_Indian.tsv -regions NA IN -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles -asciioutput
+#
+#Using SOCATv5:
+#SOCATv5 ASCII:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv5/ -socat_files SOCATv5.tsv -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles -asciioutput
+#SOCATv5 gridded:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv5/ -socat_files SOCATv5.tsv -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles
+#
+#Using SOCATv6:
+#SOCATv6 ASCII:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv6/ -socat_files SOCATv6.tsv -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles -asciioutput
+#SOCATv6 gridded, 2009:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv6/ -socat_files SOCATv6.tsv -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2009 -endyr 2009 -keepduplicates -keeptempfiles
+#SOCATv6 gridded, 2016:
+#   -socat_dir ~/data/SOCAT_ascii/SOCATv6/ -socat_files SOCATv6.tsv -sst_dir ~/data/ocean_flux_ftp/SST_reynolds_avhrr/ -sst_tail 01_OCF-SST-GLO-1M-100-REYNOLDS.nc -output_dir ~/Files/fluxengine_v3/FluxEngine/output/reanalysis_socat_output_gridded -socatversion 4 -usereynolds -startyr 2016 -endyr 2016 -keepduplicates -keeptempfiles
 
 import reanalyse_socat.reanalyse_socat_v2 as rs;
 
@@ -34,6 +57,7 @@ if __name__ == "__main__":
     
     argParsePathGroup = clParser.add_argument_group(title='Data paths');
     argParsePathGroup.add_argument("-socat_dir", help="Path to the directory containing tsv formatted SOCAT data.", default="");
+    argParsePathGroup.add_argument("-socat_files", type=str, nargs='*', help='A list of region codes to process (e.g. NA for North Atlantic). If no region codes are specified the global database is assumed.', default=None);
     argParsePathGroup.add_argument("-sst_dir", help="Path to the directory containing netCDF formatted sea sureface temperature (either Reynolds or AATSR).", default="");
     argParsePathGroup.add_argument("-sst_tail", help="The SST file name which follows yyyymm. Do not include the year or month digits.", default="");
     argParsePathGroup.add_argument("-output_dir", help="Path to the output directory", default="~/socat_reanalysis_output/");
@@ -43,20 +67,26 @@ if __name__ == "__main__":
     argParseTimeGroup.add_argument("-endyr", type=int, help='The last year to importing SOCAT data for (includes this year).', default=2010);
     
     argParseSettingsGroup = clParser.add_argument_group(title='Optional settings');
-    argParseSettingsGroup.add_argument("-regions", metavar='<keyword_list>', type=str, nargs='*', help='A list of region codes to process (e.g. NA for North Atlantic).', default=None);
-    argParseSettingsGroup.add_argument('-withcoastal',dest='withcoastal',action='store_true',help="To use the coastal data.",default=False)
+    argParseSettingsGroup.add_argument("-regions", metavar='<keyword_list>', type=str, nargs='*', help='A list of region codes to process. These will be used to name output files and should correspond to the list of file names given in -socat_files. If no region code is specified it is assumed a single file containing global data is provided.', default=["GL"]);
+    argParseSettingsGroup.add_argument('-withcoastal',dest='withcoastal',type=str,help="The region code (defined using -regions) which corresponds to coastal data. Coastal data is appended to other regions where gridcells overlap and any remaining data is analysed seperately. Do not specify if no coastal data is used. Default is None (no coastal data used).",default=None)
     argParseSettingsGroup.add_argument('-socatversion', type=int, dest='socatversion', help="The version of the SOCAT data files to read",default=2);
-    argParseSettingsGroup.add_argument('-asciioutput', dest='asciioutput', action='store_true', help="To output data as ascii lists rather than gridded netcdf.", default=True);
+    argParseSettingsGroup.add_argument('-asciioutput', dest='asciioutput', action='store_true', help="To output data as ascii lists rather than gridded netcdf.", default=False);
     argParseSettingsGroup.add_argument('-useaatsr', action='store_true', help="To use the AATSR SST data.", default=False);
-    argParseSettingsGroup.add_argument('-usereynolds', action='store_true', help="To use the Reynolds SST data.", default=True);
+    argParseSettingsGroup.add_argument('-usereynolds', action='store_true', help="To use the Reynolds SST data.", default=False);
+    argParseSettingsGroup.add_argument('-keepduplicates', action='store_true', help="Do not detect and remove duplicate data points.", default=False);
+    argParseSettingsGroup.add_argument('-keeptempfiles', action='store_true', help="Do not delete the temporary (full output) files produced by the reanalyse_socat.", default=False);
     
     clArgs = clParser.parse_args();
+    
+    if clArgs.socat_dir == None or clArgs.socat_files == None or clArgs.sst_dir == None or clArgs.sst_tail == None:
+        raise SystemExit("Error: -socat_dir, -socat_files, -sst_dir and -sst_tail are all mandatory arguments. At least one of these has not been specified.");
     
     #Check no temporary output was left in place from a previous run (if it is, delete it)
     if path.exists(temporaryOutputPath) == True:
         shutil.rmtree(temporaryOutputPath);
     
     exitCode = rs.RunReanalyseSocat(socatdir=clArgs.socat_dir,
+                         socatfiles=clArgs.socat_files,
                          sstdir=clArgs.sst_dir,
                          ssttail=clArgs.sst_tail,
                          socatversion=clArgs.socatversion,
@@ -65,34 +95,39 @@ if __name__ == "__main__":
                          startyr=clArgs.startyr,
                          endyr=clArgs.endyr,
                          asciioutput=clArgs.asciioutput,
+                         keepduplicates=clArgs.keepduplicates,
+                         withcoastal=clArgs.withcoastal,
                          output="reanalyse_socat/output/");
         
     #copy output files to the output_dir folder.
     if exitCode == 0:
-        print "SOCAT reanalysis completed successfully."
+        print "Reanalysis completed successfully."
         outputDir = path.abspath(path.expanduser(clArgs.output_dir));
         
         #Create output directory
-        if path.exists(outputDir) == False:
-            makedirs(outputDir);
-            
+        #if path.exists(outputDir) == False:
+        #    makedirs(outputDir);
         try:
-            #move relevant reanalyse_socat output files
-            shutil.move(path.join(temporaryOutputPath, "reanalysed_socat"), outputDir);
+            #copy relevant reanalyse_socat output files
+            #shutil.move(path.join(temporaryOutputPath, "reanalysed_data"), outputDir);
+            shutil.copytree(path.join(temporaryOutputPath, "reanalysed_data"), outputDir);
             
             #remove irrelevant reanalyse_socat output files
-            shutil.rmtree(temporaryOutputPath);
+            if clArgs.keeptempfiles == False:
+                shutil.rmtree(temporaryOutputPath);
+            else:
+                print "-keeptempfiles was set so full output can be viewed at:", "Output can be viewed at:", path.abspath(temporaryOutputPath);
         except shutil.Error as e: #If the output directory already exists don't delete anything and tell the user.
             if "already exists" in e.args[0]:
                 print e.args[0];
-                print "Output can be viewed at:", path.join(temporaryOutputPath, "reanalysed_socat");
+                print "Output can be viewed at:", path.join(temporaryOutputPath, "reanalysed_data");
             else: #Otherwise, propagate the exception
                 raise e;
         
         
         
 
-
+shutil.copytree(temporaryOutputPath, path.expanduser("~/Desktop/test/directory/output/folder"))
 
 
 


### PR DESCRIPTION
In this version, the socat_reanalysis tool (in the fluxengine_src/tools/ sub-directory) should work well with fluxengine and insitu data. Added and tested support for SOCATv5 and v5. There is a custom driver script called 'reanalyse_socat_driver' in the tools directory which simplifies it's use.