### PR TITLE
Remove optional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,9 @@ for i in range(len(scripts)): #Append the directory to each script name
 #list the dependencies
 dependencies = ["numpy>=1.16.4",
                 "pandas>=0.24.2",
-                "matplotlib>=3.1.0",
                 "netCDF4>=1.4.2",
                 "argparse>=1.1",
                 "scipy>=1.3.0",
-                "jupyter>=1.0.0",
                 ];
 
 #Create a list of package data files


### PR DESCRIPTION
As discussed in https://github.com/oceanflux-ghg/FluxEngine/issues/60#issuecomment-925786300, matplotlib and jupyter are only needed for the tutorials, so are not hard package dependencies.