### PR TITLE
Compatibility fixes for recent versions of Python and Numpy

### DIFF
--- a/fluxengine/core/fe_setup_tools.py
+++ b/fluxengine/core/fe_setup_tools.py
@@ -13,6 +13,7 @@ This includes:
 """
 
 from os import path, listdir, makedirs;
+import sys
 import inspect;
 import time;
 import socket; #for gethostname
@@ -26,6 +27,11 @@ from fluxengine.core import data_preprocessing as data_preprocessing; #preproces
 from fluxengine.core import process_indicator_layers as indicator_layers; #Process indicator layer functors
 from fluxengine.core import fe_core as fluxengine;
 
+if sys.version_info > (3, 10):
+    # inspect.getargspec has been removed from Python starting version 3.11.0
+    inspect_argspec = inspect.getfullargspec
+else:
+    inspect_argspec = inspect.getargspec
 
 #Gets the root fluxengine directory
 def get_fluxengine_root():
@@ -457,7 +463,7 @@ def build_k_functor(runParameters, customGTVPath=None):
                 #Check it derives from KCalculateBase - this is used as a simple way to filter out irrelevant classes
                 if issubclass(ClassHandle, k_params.KCalculationBase):
                     #To initialise the class we need to know the arguments it's __init__ function uses.
-                    initialiserArgNames = [arg for arg in inspect.getargspec(ClassHandle.__init__).args if arg != "self"];
+                    initialiserArgNames = [arg for arg in inspect_argspec(ClassHandle.__init__).args if arg != "self"];
                     
                     try:
                         #Create a dictionary of name:value pairs for the __init__ arguments. Assumes arguments match config file names.

--- a/fluxengine/tools/reanalyse_fco2/v2_f_conversion.py
+++ b/fluxengine/tools/reanalyse_fco2/v2_f_conversion.py
@@ -5,6 +5,17 @@ import numpy as np
 from . import datenum
 import tempfile
 
+# Numpy is required to be >= 1.16 according to setup.py
+np_major, np_minor, _ = np.__version__.split('.')
+if (int(np_major), int(np_minor)) >= (1, 24):
+    # Type aliases numpy.int and numpy.float have been removed from numpy
+    # starting version 1.24.0
+    np_int = int
+    np_float = float
+else:
+    np_int = np.int
+    np_float = np.float
+
 # Constants
 R = 82.0578 # cm^3 atm/(mol K)
 hPa2atm = 100. * 9.867E-06
@@ -28,22 +39,22 @@ def v2_f_conversion_wrap(jds,data_array,Tcls,Peq_cls,extrapolatetoyear=None):
       return None
    else:
       #concatenate arrays into single, structured array for return
-      result=np.recarray((jd.size,),dtype=[('jd',np.float),
+      result=np.recarray((jd.size,),dtype=[('jd',np_float),
                                            ('yr',np.int32),
                                            ('mon',np.int32),
                                            ('day', np.int32),
                                            ('hh', np.int32),
                                            ('mm', np.int32),
                                            ('ss', np.int32),
-                                           ('lat',np.float),
-                                           ('lon',np.float),
-                                           ('SST_C',np.float),
-                                           ('Tcl_C',np.float),
-                                           ('fCO2_SST',np.float),
-                                           ('fCO2_Tym',np.float),
-                                           ('pCO2_SST',np.float),
-                                           ('pCO2_Tym',np.float),
-                                           ('qf',np.int)]);
+                                           ('lat',np_float),
+                                           ('lon',np_float),
+                                           ('SST_C',np_float),
+                                           ('Tcl_C',np_float),
+                                           ('fCO2_SST',np_float),
+                                           ('fCO2_Tym',np_float),
+                                           ('pCO2_SST',np_float),
+                                           ('pCO2_Tym',np_float),
+                                           ('qf',np_int)]);
       result['jd']=jd
       result['yr']=yr;
       result['mon']=mon;


### PR DESCRIPTION
FluxEngine uses methods and type aliases that have been removed from recent versions of Python and Numpy:

- the inspect.getargspec method has been removed from Python starting version 3.11
- the numpy.int and numpy.float type aliases have been removed from Numpy starting version 1.24.0

Submitted changes provide alternatives that work on newer environments and *should* still work with older versions of Python and Numpy (I only tested on the environments I had at hand: with Python 3.12.6 with Numpy 1.26.4, and Python 3.12.7 with Numpy 2.1.3).