### PR TITLE
Adding salinity adjustments

### DIFF
--- a/fluxengine/__init__.py
+++ b/fluxengine/__init__.py
@@ -7,4 +7,4 @@ Created on Sun Apr 15 17:07:16 2018
 """
 
 
-__version__ = "4.2.1.pre2";
+__version__ = "4.2.1.pre5";

--- a/fluxengine/__init__.py
+++ b/fluxengine/__init__.py
@@ -7,4 +7,4 @@ Created on Sun Apr 15 17:07:16 2018
 """
 
 
-__version__ = "4.2.0";
+__version__ = "4.2.pre1";

--- a/fluxengine/__init__.py
+++ b/fluxengine/__init__.py
@@ -7,4 +7,4 @@ Created on Sun Apr 15 17:07:16 2018
 """
 
 
-__version__ = "4.2.pre1";
+__version__ = "4.2.1.pre2";

--- a/fluxengine/core/data_preprocessing.py
+++ b/fluxengine/core/data_preprocessing.py
@@ -196,6 +196,12 @@ def foc_to_epsilon_craig1994(datalayer):
             datalayer.fdata[i] = depth_function(0.2, a=beta);
 
 def Kudry_waterside_friction_velocity(datalayer):
+    # Waterside friction velocity as calculated following:
+    # Kudryavtsev, V., Makin, V., & Zappa, C. (2012). On the sea-surface drag and heat/mass transfer at strong winds. KNMI Scientific Report. Available at https://cdn.knmi.nl/knmi/pdf/bibliotheek/knmipubWR/WR2012-02.pdf
+
+    # Kudryavtsev, V., Chapron, B., Makin, V., & Dulov, V. (2015). On the impact of sea spray on the dynamics of the marine atmospheric boundary layer. Journal of Geophysical Research: Oceans, 120(10), 6896–6917. DOI: 10.1002/2015JC010832
+
+    # This includes sea spray reduction at high winds
     import numpy as np
     # Physical constants and parameters
     rho_a = 1.3       # air density [kg/m^3]
@@ -240,6 +246,12 @@ def Kudry_waterside_friction_velocity(datalayer):
     datalayer.fdata[mask] = UST*np.sqrt(rho_w/rho_a) # Converting air-side into waterside friction velocity
 
 def Kudry_airside_friction_velocity(datalayer):
+    # Airside friction velocity as calculated following:
+    # Kudryavtsev, V., Makin, V., & Zappa, C. (2012). On the sea-surface drag and heat/mass transfer at strong winds. KNMI Scientific Report. Available at https://cdn.knmi.nl/knmi/pdf/bibliotheek/knmipubWR/WR2012-02.pdf
+
+    # Kudryavtsev, V., Chapron, B., Makin, V., & Dulov, V. (2015). On the impact of sea spray on the dynamics of the marine atmospheric boundary layer. Journal of Geophysical Research: Oceans, 120(10), 6896–6917. DOI: 10.1002/2015JC010832
+
+    # This includes sea spray reduction at high winds
     import numpy as np
     # Physical constants and parameters
     rho_a = 1.3       # air density [kg/m^3]

--- a/fluxengine/core/data_preprocessing.py
+++ b/fluxengine/core/data_preprocessing.py
@@ -194,3 +194,91 @@ def foc_to_epsilon_craig1994(datalayer):
             beta = result.x;
             #Calculate epsilon at 2cm and write to data layer.
             datalayer.fdata[i] = depth_function(0.2, a=beta);
+
+def Kudry_waterside_friction_velocity(datalayer):
+    import numpy as np
+    # Physical constants and parameters
+    rho_a = 1.3       # air density [kg/m^3]
+    rho_w = 1e3       # water density [kg/m^3]
+    cch = 2e-2        # Charnock constant
+    ck = 0.4          # Von Karman constant
+    g = 9.8           # acceleration of gravity [m/s^2]
+
+    # 10 m height wind speed vector [m/s]
+    u10m = datalayer.fdata
+    mask = u10m !=datalayer.missing_value
+    #u10m =np.repeat(u10m[:,np.newaxis],156,axis=1)
+
+    # First guesses (vectorized)
+    ustar = np.sqrt(1.5e-3) * u10m[mask]
+    ustarn = np.sqrt(1.5e-3) * u10m[mask]
+
+    # Pre-allocate z0 arrays (handling u10 = 0 to avoid division by zero warnings)
+    z0 = np.zeros_like(u10m[mask])
+    z0n = np.zeros_like(u10m[mask])
+
+    # Perform iteration over the entire array simultaneously
+    for it in range(10):
+        # Standard Charnock relation
+        z0 = cch * (ustar**2) / g
+
+        # With spray effect reduction factor at high wind speeds
+        z0n = cch * (ustarn**2) / g * np.exp(-(u10m[mask] / 40.0)**3)
+
+        # Avoid log(0) or division by zero at u10m == 0
+        with np.errstate(divide='ignore', invalid='ignore'):
+            ustar = np.where(u10m[mask] > 0, ck * u10m[mask] / np.log(10.0 / z0), 0.0)
+            ustarn = np.where(u10m[mask] > 0, ck * u10m[mask] / np.log(10.0 / z0n), 0.0)
+
+    # Final parameter calculations (vectorized)
+    UST0 = ustar
+    Z00 = z0
+
+    UST = ustarn
+    Z0 = z0n
+
+    datalayer.fdata[mask] = UST*np.sqrt(rho_w/rho_a) # Converting air-side into waterside friction velocity
+
+def Kudry_airside_friction_velocity(datalayer):
+    import numpy as np
+    # Physical constants and parameters
+    rho_a = 1.3       # air density [kg/m^3]
+    rho_w = 1e3       # water density [kg/m^3]
+    cch = 2e-2        # Charnock constant
+    ck = 0.4          # Von Karman constant
+    g = 9.8           # acceleration of gravity [m/s^2]
+
+    # 10 m height wind speed vector [m/s]
+    u10m = datalayer.fdata
+    mask = u10m !=datalayer.missing_value
+    #u10m =np.repeat(u10m[:,np.newaxis],156,axis=1)
+
+    # First guesses (vectorized)
+    ustar = np.sqrt(1.5e-3) * u10m[mask]
+    ustarn = np.sqrt(1.5e-3) * u10m[mask]
+
+    # Pre-allocate z0 arrays (handling u10 = 0 to avoid division by zero warnings)
+    z0 = np.zeros_like(u10m[mask])
+    z0n = np.zeros_like(u10m[mask])
+
+    # Perform iteration over the entire array simultaneously
+    for it in range(10):
+        # Standard Charnock relation
+        z0 = cch * (ustar**2) / g
+
+        # With spray effect reduction factor at high wind speeds
+        z0n = cch * (ustarn**2) / g * np.exp(-(u10m[mask] / 40.0)**3)
+
+        # Avoid log(0) or division by zero at u10m == 0
+        with np.errstate(divide='ignore', invalid='ignore'):
+            ustar = np.where(u10m[mask] > 0, ck * u10m[mask] / np.log(10.0 / z0), 0.0)
+            ustarn = np.where(u10m[mask] > 0, ck * u10m[mask] / np.log(10.0 / z0n), 0.0)
+
+    # Final parameter calculations (vectorized)
+    UST0 = ustar
+    Z00 = z0
+
+    UST = ustarn
+    Z0 = z0n
+
+    datalayer.fdata[mask] = UST

--- a/fluxengine/core/data_preprocessing.py
+++ b/fluxengine/core/data_preprocessing.py
@@ -133,7 +133,11 @@ def hour_to_day(datalayer):
     datalayer.data[mask] /= 24
     datalayer.calculate_fdata();
 
-    
+def plus_one(datalayer):
+    # Data preprocessing useful for testing - it simple adds one to the dataset...
+    mask = datalayer.data != datalayer.missing_value
+    datalayer.fdata[datalayer.fdata != datalayer.missing_value] += 1
+
 #Converts 'wave to ocean energy' (foc in WaveWatch) to dissipation rate of turbulent kinetic energy (epsilon)
 #Calculates dissipation rate of turbulent energy in the top 10m (mean)
 def foc_to_epsilon(datalayer):

--- a/fluxengine/core/datalayer.py
+++ b/fluxengine/core/datalayer.py
@@ -60,7 +60,7 @@ class DataLayer:
     @classmethod
     def create_from_file(cls, infile, prod, metadata, timeIndex, transposeData=False, preprocessing=None):
         function = "(DataLayer.create_from_file)"
-        
+
         #helper which extracts the NC variable data to a numpy array.
         #converts unsigned integers to signed equivalents (necessary because missing_value values usually use negative values)
         def nc_variable_to_numpy(ncVar):
@@ -68,8 +68,8 @@ class DataLayer:
             if arr.dtype.kind == "u": #Convert unsigned integers to equivalent signed integer
                 arr = arr.astype("int"+str(arr.dtype.itemsize * 8))
             return arr
-        
-        
+
+
         #Open netCDF file
         try:
             dataset = Dataset(infile);

--- a/fluxengine/core/fe_core.py
+++ b/fluxengine/core/fe_core.py
@@ -1664,7 +1664,21 @@ class FluxEngine:
                 self.add_empty_data_layer("pco2_sst");
                 self.data["pco2_sst"].fdata = self.data["sstfnd"].fdata - 273.15;  # copy/convert sstfnd
             except (IOError, KeyError, ValueError) as e:
-                print("pco2_sst data not available and could read sstfnd so cannot proceed.");
+                print("pco2_sst data not available and couldn't read sstfnd so cannot proceed.");
+                print(type(e), "\n" + e.args);
+                return 1;
+
+        # 24/06/2026 DJF: Added ability to specify a salinity paired to p/fCO2 and allows it to be converted to the salinity dataset following Sacrimento and Gruber.
+        if "pco2_sss" in self.data:
+            print('Check that supplied pco2_sss is correct.')
+        if "pco2_sss" not in self.data:  # SOCATv4
+            try:
+                print(
+                    "No pco2_sss data were supplied. Salinity will be used instead ")
+                self.add_empty_data_layer("pco2_sss");
+                self.data["pco2_sss"].fdata = self.data["salinity"].fdata;  # copy salinity
+            except (IOError, KeyError, ValueError) as e:
+                print("pco2_sss data not available and couldn't read salinity so cannot proceed.");
                 print(type(e), "\n" + e.args);
                 return 1;
 
@@ -1911,15 +1925,17 @@ class FluxEngine:
         #######################################################
         # this may be needed when using SMOS salinity data
         # To-DO: awaiting info from Lonneke and David before implementing fully
-        pCO2_salinity_term = 0;
+
+        #24/06/2025 DJF: Adding ability to modify the pCO2sw due to salinity changes
+        # pCO2_salinity_term = 0;
         # dSalinity = salinity_rmse
         # if (salinity_option == 1):
-        #  # need to determine dS/S using original salinity (its been modified above to add the salinity_rmse)
-        #  # so (self.data["salinity"].fdata[i] - salinity_rmse) ensures that we are dealing with the original value of salinity
-        #  # using Ys=1 as a global correction following Sarmiento and Gruber, 2006)
-        # pCO2_salinity_term = 1.0*(dSalinity/(self.data["salinity"].fdata[i] - salinity_rmse) ) #TH: Commented this out, but should not be removed as may be used in the future.
+        # need to determine dS/S using original salinity (its been modified above to add the salinity_rmse)
+        # so (self.data["salinity"].fdata[i] - salinity_rmse) ensures that we are dealing with the original value of salinity
+        # using Ys=1 as a global correction following Sarmiento and Gruber, 2006)
+        # pCO2_salinity_term = runParams.gammma * ((self.data['salinity'] - self.data["pco2_sss"]) /self.data["pco2_sss"].fdata[i]) #DJF: Added this back in so we can modify pCO2sw by salinity.
         # else:
-        # pCO2_salinity_term = 0.0
+        #     pCO2_salinity_term = 0.0
 
         # if pCO2 data in sea water is provided calculated corrected values.
         if "pgas_sw" in self.data:  # Only calculate partial pressure data is available
@@ -1931,10 +1947,14 @@ class FluxEngine:
                     (self.data["sstfnd"].fdata != missing_value) &
                     (self.data["pco2_sst"].fdata != missing_value) &
                     (self.data["pgas_sw"].fdata != missing_value) &
-                    (self.data["sstskin"].fdata != 0.0)
+                    (self.data["sstskin"].fdata != 0.0) &
+                    (self.data["pco2_sss"].fdata != missing_value)
             )
 
             if runParams.GAS == 'CO2' and runParams.pco2_data_selection != 3:
+                self.add_empty_data_layer("pCO2_salinity_term");
+                self.data["pCO2_salinity_term"].fdata[mask] = runParams.gammma * ((self.data['salinity'].fdata[mask] - self.data["pco2_sss"].fdata[mask]) / self.data["pco2_sss"].fdata[mask]) #DJF: Added this back in so we can modify pCO2sw by salinity.
+
                 self.data["pgas_sw"].fdata[mask] = pco2_increment + (
                         self.data["pgas_sw"].fdata[mask] * np.exp(
                     (0.0423 * (self.data["sstfndC"].fdata[mask] - self.data["pco2_sst"].fdata[mask]))
@@ -1942,7 +1962,7 @@ class FluxEngine:
                     + pCO2_salinity_term
                 )
                 )
-                self.data["pgas_sw"].fdata[~mask] = self.data["pgas_sw"].fdata[~mask]
+                # self.data["pgas_sw"].fdata[~mask] = self.data["pgas_sw"].fdata[~mask] #DJF 24/06/2026: Dont think this is needed as above now modifies pgas_sw directly so anything not modified above within mask is unchanged.
             else:
                 self.data["pgas_sw"].fdata[mask] = self.data["pgas_sw"].fdata[mask]
 

--- a/fluxengine/core/fe_core.py
+++ b/fluxengine/core/fe_core.py
@@ -1953,13 +1953,13 @@ class FluxEngine:
 
             if runParams.GAS == 'CO2' and runParams.pco2_data_selection != 3:
                 self.add_empty_data_layer("pCO2_salinity_term");
-                self.data["pCO2_salinity_term"].fdata[mask] = runParams.gammma * ((self.data['salinity'].fdata[mask] - self.data["pco2_sss"].fdata[mask]) / self.data["pco2_sss"].fdata[mask]) #DJF: Added this back in so we can modify pCO2sw by salinity.
+                self.data["pCO2_salinity_term"].fdata[mask] = runParams.gamma * ((self.data['salinity'].fdata[mask] - self.data["pco2_sss"].fdata[mask]) / self.data["pco2_sss"].fdata[mask]) #DJF: Added this back in so we can modify pCO2sw by salinity.
 
                 self.data["pgas_sw"].fdata[mask] = pco2_increment + (
                         self.data["pgas_sw"].fdata[mask] * np.exp(
                     (0.0423 * (self.data["sstfndC"].fdata[mask] - self.data["pco2_sst"].fdata[mask]))
                     - (0.0000435 * ((self.data["sstfndC"].fdata[mask] ** 2) - (self.data["pco2_sst"].fdata[mask] ** 2)))
-                    + pCO2_salinity_term
+                    + self.data["pCO2_salinity_term"].fdata[mask]
                 )
                 )
                 # self.data["pgas_sw"].fdata[~mask] = self.data["pgas_sw"].fdata[~mask] #DJF 24/06/2026: Dont think this is needed as above now modifies pgas_sw directly so anything not modified above within mask is unchanged.

--- a/fluxengine/core/fe_core.py
+++ b/fluxengine/core/fe_core.py
@@ -1381,7 +1381,7 @@ class FluxEngine:
             # Apply mask to each data layer
             for dataLayerName in self.data:
                 if dataLayerName != "mask":
-                    self.data[dataLayerName].fdata[toIgnore] = self.data[dataLayerName].missing_value = True;
+                    self.data[dataLayerName].fdata[toIgnore] = self.data[dataLayerName].missing_value;
 
     def _run_fluxengine(self, runParams):
         function = "(ofluxghg_flux_calc, FluxEngine._run_fluxengine_)";
@@ -1948,7 +1948,8 @@ class FluxEngine:
                     (self.data["pco2_sst"].fdata != missing_value) &
                     (self.data["pgas_sw"].fdata != missing_value) &
                     (self.data["sstskin"].fdata != 0.0) &
-                    (self.data["pco2_sss"].fdata != missing_value)
+                    (self.data["pco2_sss"].fdata != missing_value) &
+                    (self.data["salinity"].fdata != missing_value)
             )
 
             if runParams.GAS == 'CO2' and runParams.pco2_data_selection != 3:

--- a/fluxengine/core/fe_setup_tools.py
+++ b/fluxengine/core/fe_setup_tools.py
@@ -58,7 +58,7 @@ def read_config_file(configPath, verbose=False):
                     configVariables[name] = value
                 else:
                     print("Warning: Duplicate definition in config file for '%s'. The first definition will be used." % name)
-                    
+
             else: #All none variable assignment lines
                 if line == "" or line.strip() == "" or line.strip()[0] == "#": #ignore blank and comment lines
                     continue
@@ -67,7 +67,7 @@ def read_config_file(configPath, verbose=False):
                 #If we get to here, it's an invalid config line
                 raise ValueError("Invalid line in configuration file. Couldn't parse config. Offending line:\n"+line)
     except Exception as e: #Catch-all other parse errors and report the offending line
-        #Print additional info then reraise the exception    
+        #Print additional info then reraise the exception
         print("Error while parsing config file at path:", configPath)
         print(type(e), e.args)
         raise(e)
@@ -99,7 +99,7 @@ def read_config_metadata(settingsPath, verbose=False):
         print("Parsing settings file at:", settingsPath)
     tree = ET.parse(settingsPath)
     root = tree.getroot()
-    
+
     # Read config metadata for each variable
     varMetadata = {}
     configParametersElement = root.find("ConfigParameters")
@@ -286,7 +286,7 @@ def verify_config_variables(configVariables, metadata, verbose=False):
             continue
         except ValueError:
             pass #try float
-            
+
         #is it a float?
         try:
             configVariables[varName] = float(configVariables[varName])
@@ -531,7 +531,7 @@ def build_k_functor(runParameters, customGTVPath=None):
 def get_preprocessing_funcs(funcNamesArg):
     function = inspect.stack()[0][1] + ", " + inspect.stack()[0][3]
     functionList = []
-    
+
     # get a list of each funcName by splitting on commas
     funcNames = [s.strip() for s in funcNamesArg.split(',')]
     for funcName in funcNames:
@@ -767,7 +767,7 @@ def run_fluxengine(configFilePath, startDate, endDate, singleRun=False, verbose=
 
                 #Check for successful run, if one fails don't run the rest.
                 if returnCode != 0:
-                    print(("There was an error running flux engine: "+returnCode+"\n"%function))
+                    print(("There was an error running flux engine: "+str(returnCode)+"\n"%function))
                     print("Exiting...")
                     return (returnCode, fe)
                 else:

--- a/fluxengine/core/settings.xml
+++ b/fluxengine/core/settings.xml
@@ -454,6 +454,8 @@
 		<Variable name="kb_asymmetry" required="true" type="float" default="1.0"></Variable>
 		<Variable name="bubble_cool_skin" required="true" type="switch" default="no"></Variable>
 
+		<Variable name="gamma" required="true" type="float" default="1.0"></Variable>
+
 		<Variable name="bias_sstskin_due_rain" required="true" type="switch" default="no"></Variable>
 		<Variable name="bias_sstskin_due_rain_value" required="true" type="float" default="0.0"></Variable>
 		<Variable name="bias_sstskin_due_rain_intensity" required="true" type="float" default="0.0"></Variable>

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open(path.join('README.md'), encoding='utf-8') as f:
 #Main setup object.
 setuptools.setup(
     name="fluxengine",
-    version="4.2.1.pre2",
+    version="4.2.1.pre5",
     author="Daniel Ford, Tom Holding and Jamie Shutler",
     author_email="d.ford@exeter.ac.uk, j.d.shutler@exeter.ac.uk",
     description="Open-source toolkit for calculating atmosphere-ocean gas transfer",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open(path.join('README.md'), encoding='utf-8') as f:
 #Main setup object.
 setuptools.setup(
     name="fluxengine",
-    version="4.2.0",
+    version="4.2.1.pre2",
     author="Daniel Ford, Tom Holding and Jamie Shutler",
     author_email="d.ford@exeter.ac.uk, j.d.shutler@exeter.ac.uk",
     description="Open-source toolkit for calculating atmosphere-ocean gas transfer",


### PR DESCRIPTION
Adds additional functionality to FluxEngine and adds additional preprocessing functions.

1) Adds the ability to include an adjustment to f/pCO2 due to salinity variation between the salinity paired with p/fCO2 and the salinity used in the flux calculation. This new non-required input of 'pco2_sss' acts in the same way as 'pco2_sst' where the p/fCO2 is corrected from the temperature provided in 'pco2_sst' to the subskin sst used in the flux calculation. An additional parameter gamma, can be specified in the Fluxengine config to specify the sensitivity (ability to provide a space/time varying gamma not implemented currently). The implementation is based on Sarmiento and Gruber (2006).

2) Fixes a bug in the masking ability of FluxEngine due to a legacy incorrect definition to define the fill_value.

3) Fixes an error in the printing of error codes when FluxEngine does not successfully run (i.e FluxEngine would hard crash after a soft crash due to the printing to the console)

4) Adds 'gamma' to the default values listing in settings.xml

5) Adds additional preprocessing functions that can be used for testing, or in gas transfer parameterisations.

Identified bug: Dan F/Dan W identified the fluxengine logging does not appear to work (file is generated but does not output anything). Dan F to investigate and fix in later FluxEngine version.